### PR TITLE
Support Websocket streaming in Getting logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,34 +3,19 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.22.0"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -62,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -77,49 +62,50 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -129,15 +115,15 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -146,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -157,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -174,33 +160,24 @@ checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "atomic"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.3.0"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "backtrace"
-version = "0.3.73"
+name = "autocfg"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -228,21 +205,21 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.5.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ec96fe9a81b5e365f9db71fe00edc4fe4ca2cc7dcb7861f0603012a7caa210"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "cc",
  "cfg-if",
  "constant_time_eq",
@@ -258,10 +235,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.10.0"
+name = "block2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "serde",
@@ -269,21 +255,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "byteorder"
@@ -299,38 +285,44 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "camino"
-version = "1.1.8"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3054fea8a20d8ff3968d5b22cc27501d2b08dc4decdb31b184323f00c5ef23bb"
+checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -357,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -367,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "clap-verbosity-flag"
-version = "2.2.1"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d19864d6b68464c59f7162c9914a0b569ddc2926b4a2d71afe62a9738eff53"
+checksum = "34c77f67047557f62582784fd7482884697731b2932c7d37ced54bce2312e1e2"
 dependencies = [
  "clap",
  "log",
@@ -377,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -389,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -401,31 +393,42 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width 0.2.2",
+]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cookie"
@@ -436,6 +439,24 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -456,27 +477,27 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -493,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -524,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -534,28 +555,61 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.126"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4eae4b7fc8dcb0032eb3b1beee46b38d371cdeaf2d0c64b9944f6f69ad7755"
+checksum = "2b788601e7e3e6944d9b37efbae0bee7ee44d9aab533838d4854f631534a1a49"
 dependencies = [
  "cc",
+ "cxx-build",
+ "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
+ "foldhash",
  "link-cplusplus",
 ]
 
 [[package]]
-name = "cxxbridge-flags"
-version = "1.0.126"
+name = "cxx-build"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719d6197dc016c88744aff3c0d0340a01ecce12e8939fc282e7c8f583ee64bc6"
+checksum = "5e11d62eb0de451f6d3aa83f2cec0986af61c23bd7515f1e2d6572c6c9e53c96"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a368ed4a0fd83ebd3f2808613842d942a409c41cc24cd9d83f1696a00d78afe"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9571a7c69f236d7202f517553241496125ed56a86baa1ce346d02aa72357c74"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.126"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35de3b547387863c8f82013c4f79f1c2162edee956383e4089e1d04c18c4f16c"
+checksum = "eba2aaae28ca1d721d3f364bb29d51811921e7194c08bb9eaf745c8ab8d81309"
 dependencies = [
+ "indexmap",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -569,24 +623,24 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
 
 [[package]]
 name = "deunicode"
-version = "1.6.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "devise"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6eacefd3f541c66fc61433d65e54e0e46e0a029a819a7dbbc7a7b489e8a85f8"
+checksum = "f1d90b0c4c777a2cad215e3c7be59ac7c15adf45cf76317009b7d096d46f651d"
 dependencies = [
  "devise_codegen",
  "devise_core",
@@ -594,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "devise_codegen"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8cf4b8dd484ede80fd5c547592c46c3745a617c8af278e2b72bea86b2dfed6"
+checksum = "71b28680d8be17a570a2334922518be6adc3f58ecc880cbb404eaeb8624fd867"
 dependencies = [
  "devise_core",
  "quote",
@@ -604,11 +658,11 @@ dependencies = [
 
 [[package]]
 name = "devise_core"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b50dba0afdca80b187392b24f2499a88c336d5a8493e4b4ccfb608708be56a"
+checksum = "b035a542cf7abf01f2e3c4d5a7acbaebfefe120ae4efc7bde3df98186e4b8af7"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
@@ -626,52 +680,73 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -691,25 +766,36 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+dependencies = [
+ "cfg-if",
+ "home",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "figment"
@@ -717,7 +803,7 @@ version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
- "atomic 0.6.0",
+ "atomic 0.6.1",
  "pear",
  "serde",
  "toml",
@@ -727,21 +813,27 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.31"
+name = "find-msvc-tools"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -754,19 +846,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.1"
+name = "foldhash"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -779,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -789,15 +887,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -806,15 +904,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -823,21 +921,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -894,13 +992,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -910,22 +1010,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
-
-[[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "global_placeholders"
@@ -938,15 +1034,15 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
 dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -955,16 +1051,16 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "ignore",
  "walkdir",
 ]
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -981,15 +1077,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hcl-edit"
-version = "0.8.1"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46510177a76e68ccd7d75c5af6dfc7d9bf14d5b274211cc35d5abe7f6e72d5b0"
+checksum = "88489f7cdf733b4c7798403f72d2c16fdc2b720e82c5151055f618a9b49afc1c"
 dependencies = [
  "fnv",
  "hcl-primitives",
@@ -999,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "hcl-primitives"
-version = "0.1.5"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaef0959c97781fc9aba104a08e513a14f995b7c12fdcf940d94252d2e4fa884"
+checksum = "829a11d304c89e2cfe0dbb494a686bbe2b48ade17705c62cd1957b04aa4630f6"
 dependencies = [
  "itoa",
  "kstring",
@@ -1012,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "hcl-rs"
-version = "0.18.0"
+version = "0.18.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba31dbfca0e197057f6d9a070cf87a68d93da5f551d4ad0d44e0f274f7179669"
+checksum = "48af7144c49a8db969e8a9d00cd470e1a446a3a73f6fa5eafc1eeb3d44d61ff4"
 dependencies = [
  "hcl-edit",
  "hcl-primitives",
@@ -1038,23 +1134,17 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1070,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1091,10 +1181,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "httparse"
-version = "1.9.4"
+name = "http-body"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -1113,15 +1226,15 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1129,15 +1242,36 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
  "want",
 ]
 
@@ -1149,22 +1283,64 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.32",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.60"
+name = "hyper-rustls"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.3.1",
+ "hyper 1.8.1",
+ "hyper-util",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.1",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -1179,26 +1355,118 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "icu_collections"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
 name = "ignore"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
 dependencies = [
  "crossbeam-deque",
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -1225,13 +1493,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1246,7 +1515,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
@@ -1254,44 +1523,55 @@ dependencies = [
  "newline-converter",
  "once_cell",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1313,63 +1593,68 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.18",
 ]
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
+name = "litemap"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loom"
@@ -1387,6 +1672,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "macros-rs"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,24 +1685,24 @@ checksum = "cb1feaac5c34086868f3f439dabbd71baf6a785f256aacdde7c66c95b56b12d6"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "merkle_hash"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3edd3572d1a7b4e1b7ce5bb3af05405a8aeab2ec04b29d9779e72ad576ce4f38"
+checksum = "025450e7f75788743d2f9465c120a0ad0b350367715e1230c0d21a9e4a8fdc9d"
 dependencies = [
  "blake3",
  "camino",
@@ -1442,11 +1733,12 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
- "adler",
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1463,14 +1755,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1482,7 +1773,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.1.0",
+ "http 1.3.1",
  "httparse",
  "memchr",
  "mime",
@@ -1507,8 +1798,20 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -1524,12 +1827,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1549,28 +1851,184 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
-name = "object"
-version = "0.36.3"
+name = "objc2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
- "memchr",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -1580,20 +2038,19 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_info"
-version = "3.8.2"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
+checksum = "7c39b5918402d564846d5aba164c09a66cc88d232179dfd3e3c619a25a268392"
 dependencies = [
+ "android_system_properties",
  "log",
+ "nix 0.30.1",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
  "serde",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "papergrid"
@@ -1605,14 +2062,14 @@ dependencies = [
  "ansitok",
  "bytecount",
  "fnv",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1620,15 +2077,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1665,26 +2122,25 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.7.11"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+checksum = "cbcfd20a6d4eeba40179f05735784ad32bdaef05ce8e8af05f180d45bb3e7e22"
 dependencies = [
  "memchr",
- "thiserror 1.0.63",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.11"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+checksum = "51f72981ade67b1ca6adc26ec221be9f463f2b5839c7508998daa17c23d94d7f"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1692,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.11"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+checksum = "dee9efd8cdb50d719a80088b76f81aec7c41ed6d522ee750178f83883d271625"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1705,29 +2161,28 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.11"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+checksum = "bf1d70880e76bdc13ba52eafa6239ce793d85c8e43896507e43dd8984ff05b82"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -1735,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand 0.8.5",
@@ -1745,18 +2200,18 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1788,14 +2243,14 @@ dependencies = [
  "log",
  "macros-rs",
  "merkle_hash",
- "nix",
+ "nix 0.27.1",
  "num_cpus",
  "once_cell",
  "os_info",
  "pretty_env_logger",
  "prometheus",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "rocket",
  "rocket_ws",
  "ron",
@@ -1816,6 +2271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,9 +2287,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
@@ -1898,7 +2362,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 1.0.63",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1908,10 +2372,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
-name = "quote"
-version = "1.0.36"
+name = "quinn"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.35",
+ "socket2 0.6.1",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.1",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -1969,7 +2488,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1983,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -1993,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -2009,38 +2528,38 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
- "thiserror 1.0.63",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2049,47 +2568,32 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
@@ -2104,9 +2608,9 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -2119,7 +2623,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2133,16 +2637,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.8"
+name = "reqwest"
+version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2212,7 +2755,7 @@ dependencies = [
  "either",
  "futures",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.32",
  "indexmap",
  "log",
  "memchr",
@@ -2246,16 +2789,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "serde",
  "serde_derive",
 ]
 
 [[package]]
 name = "rust-embed"
-version = "8.5.0"
+version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
+checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -2264,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.5.0"
+version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
+checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2278,44 +2821,31 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.5.0"
+version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
+checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
 dependencies = [
  "sha2",
  "walkdir",
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
+name = "rustc-hash"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.14",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
-dependencies = [
- "bitflags 2.6.0",
- "errno",
- "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2360,6 +2890,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2386,15 +2917,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -2418,6 +2949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scratch"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,24 +2966,34 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2455,21 +3002,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -2512,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2532,9 +3080,9 @@ dependencies = [
 
 [[package]]
 name = "shellexpand"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
 dependencies = [
  "dirs",
 ]
@@ -2547,9 +3095,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2557,9 +3105,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio 0.8.11",
@@ -2568,12 +3116,18 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simple-logging"
@@ -2588,18 +3142,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slug"
@@ -2613,18 +3164,28 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2641,6 +3202,12 @@ checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "state"
@@ -2698,6 +3265,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,7 +3315,7 @@ dependencies = [
  "ansitok",
  "papergrid",
  "tabled_derive",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2757,22 +3344,22 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.4",
  "once_cell",
- "rustix 0.38.34",
- "windows-sys 0.59.0",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tera"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee"
+checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2787,7 +3374,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slug",
- "unic-segment",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2801,11 +3388,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.63",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -2819,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2852,19 +3439,18 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -2877,25 +3463,35 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.8.0"
+name = "tinystr"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2908,27 +3504,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
- "mio 1.0.2",
+ "mio 1.1.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2957,9 +3552,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2991,14 +3586,14 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tungstenite 0.28.0",
- "webpki-roots 0.26.3",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3009,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3021,25 +3616,71 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -3049,9 +3690,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -3060,9 +3701,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3071,9 +3712,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3092,14 +3733,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -3123,12 +3764,12 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.8.5",
  "sha1",
- "thiserror 1.0.63",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
 ]
@@ -3141,7 +3782,7 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.9.2",
@@ -3155,9 +3796,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ubyte"
@@ -3170,9 +3811,9 @@ dependencies = [
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uncased"
@@ -3185,102 +3826,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "unic-char-property"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
-dependencies = [
- "unic-char-range",
-]
-
-[[package]]
-name = "unic-char-range"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
-
-[[package]]
-name = "unic-common"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
-
-[[package]]
-name = "unic-segment"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23"
-dependencies = [
- "unic-ucd-segment",
-]
-
-[[package]]
-name = "unic-ucd-segment"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700"
-dependencies = [
- "unic-char-property",
- "unic-char-range",
- "unic-ucd-version",
-]
-
-[[package]]
-name = "unic-ucd-version"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
-dependencies = [
- "unic-common",
-]
-
-[[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -3296,12 +3875,12 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "update-informer"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8811797a24ff123db3c6e1087aa42551d03d772b3724be421ad063da1f5f3f"
+checksum = "67b27dcf766dc6ad64c2085201626e1a7955dc1983532bfc8406d552903ace2a"
 dependencies = [
- "directories",
- "reqwest",
+ "etcetera",
+ "reqwest 0.12.24",
  "semver",
  "serde",
  "serde_json",
@@ -3310,31 +3889,46 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "2.10.1"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
  "flate2",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls 0.23.35",
  "rustls-pki-types",
  "serde",
  "serde_json",
- "url",
- "webpki-roots 0.26.3",
+ "ureq-proto",
+ "utf-8",
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
 ]
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -3342,6 +3936,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3364,9 +3964,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf0e16c02bc4bf5322ab65f10ab1149bdbcaa782cba66dc7057370a3f8190be"
+checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -3391,15 +3991,15 @@ dependencies = [
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vecmap-rs"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78fc839a22ab6c4e2f48cf5b935064188148258d467f49323134d503dd08294"
+checksum = "f9758649b51083aa8008666f41c23f05abca1766aad4cc447b195dd83ef1297b"
 dependencies = [
  "serde",
 ]
@@ -3452,9 +4052,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -3467,47 +4067,35 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3515,28 +4103,41 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3550,9 +4151,18 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.3"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3575,11 +4185,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3599,11 +4209,61 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3634,6 +4294,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3657,11 +4335,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3677,6 +4372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3687,6 +4388,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3701,10 +4408,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3719,6 +4438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3729,6 +4454,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3743,6 +4474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3755,10 +4492,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.6.18"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -3780,13 +4523,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
-name = "xattr"
-version = "1.5.1"
+name = "writeable"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "rustix",
 ]
 
 [[package]]
@@ -3799,20 +4548,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.7.35"
+name = "yoke"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "byteorder",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
+dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3820,10 +4591,64 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.8.1"
+name = "zerofrom"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -163,7 +163,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -293,9 +293,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "camino"
@@ -396,7 +396,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -558,8 +558,14 @@ checksum = "35de3b547387863c8f82013c4f79f1c2162edee956383e4089e1d04c18c4f16c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "deranged"
@@ -606,7 +612,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -764,6 +770,7 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -787,10 +794,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "futures-sink"
@@ -813,6 +842,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -871,6 +901,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -1110,7 +1152,7 @@ dependencies = [
  "hyper",
  "rustls 0.21.12",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -1618,7 +1660,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1634,7 +1676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.63",
  "ucd-trie",
 ]
 
@@ -1658,7 +1700,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1698,7 +1740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1735,6 +1777,7 @@ dependencies = [
  "cxx",
  "env_logger",
  "flate2",
+ "futures",
  "global_placeholders",
  "hcl-rs",
  "home",
@@ -1754,6 +1797,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rocket",
+ "rocket_ws",
  "ron",
  "ryu",
  "serde",
@@ -1764,6 +1808,7 @@ dependencies = [
  "tera",
  "termcolor",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "toml",
  "update-informer",
  "utoipa",
@@ -1821,9 +1866,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -1836,7 +1881,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
  "version_check",
  "yansi",
 ]
@@ -1853,7 +1898,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1872,14 +1917,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1889,7 +1950,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1898,7 +1969,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1942,9 +2022,9 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1964,7 +2044,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2042,7 +2122,7 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2060,7 +2140,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -2088,7 +2168,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "ref-cast",
  "rocket_codegen",
  "rocket_http",
@@ -2117,7 +2197,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.74",
+ "syn 2.0.111",
  "unicode-xid",
  "version_check",
 ]
@@ -2147,6 +2227,16 @@ dependencies = [
  "time",
  "tokio",
  "uncased",
+]
+
+[[package]]
+name = "rocket_ws"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f1877668c937b701177c349f21383c556cd3bb4ba8fa1d07fa96ccb3a8782e"
+dependencies = [
+ "rocket",
+ "tokio-tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -2182,7 +2272,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.74",
+ "syn 2.0.111",
  "walkdir",
 ]
 
@@ -2242,15 +2332,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.103.8",
  "subtle",
  "zeroize",
 ]
@@ -2266,9 +2356,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2282,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2357,7 +2450,7 @@ checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2404,6 +2497,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2578,9 +2682,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2678,7 +2782,7 @@ dependencies = [
  "percent-encoding",
  "pest",
  "pest_derive",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
@@ -2701,7 +2805,16 @@ version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.63",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -2712,7 +2825,18 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2808,7 +2932,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2822,6 +2946,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.35",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,6 +2964,34 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite 0.28.0",
+ "webpki-roots 0.26.3",
 ]
 
 [[package]]
@@ -2904,7 +3066,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2951,6 +3113,45 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.63",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.17",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "typenum"
@@ -3117,7 +3318,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.12",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3135,6 +3336,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
@@ -3164,7 +3371,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3250,6 +3457,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3271,7 +3487,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -3305,7 +3521,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3558,6 +3774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
 name = "xattr"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3594,7 +3816,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,12 +47,15 @@ num_cpus = "1.16.0"
 
 tokio = { version = "1.39.2", features = ["full"] }
 rocket = { version = "0.5.1", features = ["json"] }
+rocket_ws = "0.1.1"
 
 tabled = { version = "0.15.0", features = ["ansi"] }
 chrono = { version = "0.4.38", features = ["serde"] }
 serde = { version = "1.0.208", features = ["derive"] }
 nix = { version = "0.27.1", features = ["process", "signal"] }
 utoipa = { version = "4.2.3", features = ["serde_yaml", "non_strict_integers"] }
+tokio-tungstenite = { version = "0.28.0", features = ["rustls-tls-webpki-roots", "url"] }
+futures = "0.3.30"
 
 
 [dependencies.reqwest]

--- a/build.rs
+++ b/build.rs
@@ -46,11 +46,14 @@ fn download_node() -> PathBuf {
     #[cfg(all(target_arch = "aarch64"))]
     let target_arch = "arm64";
 
-    let download_url = format!("https://nodejs.org/dist/v{NODE_VERSION}/node-v{NODE_VERSION}-{target_os}-{target_arch}.tar.gz");
+    let download_url = format!(
+        "https://nodejs.org/dist/v{NODE_VERSION}/node-v{NODE_VERSION}-{target_os}-{target_arch}.tar.gz"
+    );
 
     /* paths */
     let download_dir = Path::new("target").join("downloads");
-    let node_extract_dir = download_dir.join(format!("node-v{NODE_VERSION}-{target_os}-{target_arch}"));
+    let node_extract_dir =
+        download_dir.join(format!("node-v{NODE_VERSION}-{target_os}-{target_arch}"));
 
     if node_extract_dir.is_dir() {
         return node_extract_dir;
@@ -65,7 +68,10 @@ fn download_node() -> PathBuf {
         panic!("Failed to extract Node.js: {:?}", err)
     }
 
-    println!("cargo:rustc-env=NODE_HOME={}", node_extract_dir.to_str().unwrap());
+    println!(
+        "cargo:rustc-env=NODE_HOME={}",
+        node_extract_dir.to_str().unwrap()
+    );
 
     return node_extract_dir;
 }
@@ -121,13 +127,30 @@ fn main() {
     /* version attributes */
     let date = chrono::Utc::now();
     let profile = env::var("PROFILE").unwrap();
-    let output = Command::new("git").args(&["rev-parse", "--short=10", "HEAD"]).output().unwrap();
-    let output_full = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
+    let output = Command::new("git")
+        .args(&["rev-parse", "--short=10", "HEAD"])
+        .output()
+        .unwrap();
+    let output_full = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
 
     println!("cargo:rustc-env=TARGET={}", env::var("TARGET").unwrap());
-    println!("cargo:rustc-env=GIT_HASH={}", String::from_utf8(output.stdout).unwrap());
-    println!("cargo:rustc-env=GIT_HASH_FULL={}", String::from_utf8(output_full.stdout).unwrap());
-    println!("cargo:rustc-env=BUILD_DATE={}-{}-{}", date.year(), date.month(), date.day());
+    println!(
+        "cargo:rustc-env=GIT_HASH={}",
+        String::from_utf8(output.stdout).unwrap()
+    );
+    println!(
+        "cargo:rustc-env=GIT_HASH_FULL={}",
+        String::from_utf8(output_full.stdout).unwrap()
+    );
+    println!(
+        "cargo:rustc-env=BUILD_DATE={}-{}-{}",
+        date.year(),
+        date.month(),
+        date.day()
+    );
 
     /* profile matching */
     match profile.as_str() {
@@ -157,5 +180,7 @@ fn main() {
         "src/webui/tailwind.config.mjs",
     ];
 
-    watched.iter().for_each(|file| println!("cargo:rerun-if-changed={file}"));
+    watched
+        .iter()
+        .for_each(|file| println!("cargo:rerun-if-changed={file}"));
 }

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
 use chrono::Datelike;
 use flate2::read::GzDecoder;
-use reqwest;
 use tar::Archive;
 
 use std::{
@@ -19,7 +18,7 @@ fn extract_tar_gz(tar: &PathBuf, download_dir: &PathBuf) -> io::Result<()> {
     let mut archive = Archive::new(decoder);
 
     archive.unpack(download_dir)?;
-    Ok(fs::remove_file(tar)?)
+    fs::remove_file(tar)
 }
 
 fn download_file(url: String, destination: &PathBuf, download_dir: &PathBuf) {
@@ -73,7 +72,7 @@ fn download_node() -> PathBuf {
         node_extract_dir.to_str().unwrap()
     );
 
-    return node_extract_dir;
+    node_extract_dir
 }
 
 fn download_then_build(node_extract_dir: PathBuf) {
@@ -128,11 +127,11 @@ fn main() {
     let date = chrono::Utc::now();
     let profile = env::var("PROFILE").unwrap();
     let output = Command::new("git")
-        .args(&["rev-parse", "--short=10", "HEAD"])
+        .args(["rev-parse", "--short=10", "HEAD"])
         .output()
         .unwrap();
     let output_full = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .unwrap();
 
@@ -159,7 +158,7 @@ fn main() {
             println!("cargo:rustc-env=PROFILE=release");
 
             /* cleanup */
-            fs::remove_dir_all(format!("src/webui/dist")).ok();
+            fs::remove_dir_all("src/webui/dist".to_string()).ok();
 
             /* pre-build */
             let path = download_node();

--- a/build.rs
+++ b/build.rs
@@ -158,7 +158,7 @@ fn main() {
             println!("cargo:rustc-env=PROFILE=release");
 
             /* cleanup */
-            fs::remove_dir_all("src/webui/dist".to_string()).ok();
+            fs::remove_dir_all("src/webui/dist").ok();
 
             /* pre-build */
             let path = download_node();

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -17,8 +17,12 @@ pub enum Item {
 }
 
 impl Validatable for Args {
-    fn from_id(id: usize) -> Self { Args::Id(id) }
-    fn from_string(s: String) -> Self { Args::Script(s) }
+    fn from_id(id: usize) -> Self {
+        Args::Id(id)
+    }
+    fn from_string(s: String) -> Self {
+        Args::Script(s)
+    }
 
     fn get_string(&self) -> Option<&str> {
         match self {
@@ -29,8 +33,12 @@ impl Validatable for Args {
 }
 
 impl Validatable for Item {
-    fn from_id(id: usize) -> Self { Item::Id(id) }
-    fn from_string(s: String) -> Self { Item::Name(s) }
+    fn from_id(id: usize) -> Self {
+        Item::Id(id)
+    }
+    fn from_string(s: String) -> Self {
+        Item::Name(s)
+    }
 
     fn get_string(&self) -> Option<&str> {
         match self {

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -37,7 +37,7 @@ struct Watch {
 
 impl Process {
     fn get_watch_path(&self) -> Option<String> {
-        self.watch.as_ref().and_then(|w| Some(w.path.clone()))
+        self.watch.as_ref().map(|w| w.path.clone())
     }
 }
 
@@ -101,7 +101,7 @@ pub fn read_hcl(path: &String) {
 
     servers
         .iter()
-        .for_each(|server| super::Internal::list(&string!("default"), &server));
+        .for_each(|server| super::Internal::list(&string!("default"), server));
     println!(
         "{} Applied startProcess to imported items",
         *helpers::SUCCESS
@@ -152,7 +152,7 @@ pub fn export_hcl(item: &Item, path: &Option<String>) {
 
         if Exists::check(&path).file() {
             let mut file = OpenOptions::new()
-                .write(true)
+                
                 .append(true)
                 .open(path.clone())
                 .unwrap();
@@ -163,14 +163,12 @@ pub fn export_hcl(item: &Item, path: &Option<String>) {
                     string!(err).white()
                 )
             }
-        } else {
-            if let Err(err) = fs::write(path.clone(), serialized) {
-                crashln!(
-                    "{} Error writing file.\n{}",
-                    *helpers::FAIL,
-                    string!(err).white()
-                )
-            }
+        } else if let Err(err) = fs::write(path.clone(), serialized) {
+            crashln!(
+                "{} Error writing file.\n{}",
+                *helpers::FAIL,
+                string!(err).white()
+            )
         }
 
         println!("{} Exported process {id} to {path}", *helpers::SUCCESS);
@@ -178,7 +176,7 @@ pub fn export_hcl(item: &Item, path: &Option<String>) {
 
     match item {
         Item::Id(id) => fetch_process(*id),
-        Item::Name(name) => match runner.find(&name, &string!("internal")) {
+        Item::Name(name) => match runner.find(name, &string!("internal")) {
             Some(id) => fetch_process(id),
             None => crashln!("{} Process ({name}) not found", *helpers::FAIL),
         },

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -151,11 +151,7 @@ pub fn export_hcl(item: &Item, path: &Option<String>) {
         let serialized = hcl::to_string(&data).unwrap();
 
         if Exists::check(&path).file() {
-            let mut file = OpenOptions::new()
-                
-                .append(true)
-                .open(path.clone())
-                .unwrap();
+            let mut file = OpenOptions::new().append(true).open(path.clone()).unwrap();
             if let Err(err) = writeln!(file, "{}", serialized) {
                 crashln!(
                     "{} Error writing to file.\n{}",

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -36,7 +36,9 @@ struct Watch {
 }
 
 impl Process {
-    fn get_watch_path(&self) -> Option<String> { self.watch.as_ref().and_then(|w| Some(w.path.clone())) }
+    fn get_watch_path(&self) -> Option<String> {
+        self.watch.as_ref().and_then(|w| Some(w.path.clone()))
+    }
 }
 
 pub fn read_hcl(path: &String) {
@@ -46,12 +48,20 @@ pub fn read_hcl(path: &String) {
 
     let contents = match fs::read_to_string(path) {
         Ok(contents) => contents,
-        Err(err) => crashln!("{} Cannot read file to import.\n{}", *helpers::FAIL, string!(err).white()),
+        Err(err) => crashln!(
+            "{} Cannot read file to import.\n{}",
+            *helpers::FAIL,
+            string!(err).white()
+        ),
     };
 
     let hcl_parsed: ProcessWrapper = match hcl::from_str(&contents) {
         Ok(hcl) => hcl,
-        Err(err) => crashln!("{} Cannot parse imported file.\n{}", *helpers::FAIL, string!(err).white()),
+        Err(err) => crashln!(
+            "{} Cannot parse imported file.\n{}",
+            *helpers::FAIL,
+            string!(err).white()
+        ),
     };
 
     for (name, item) in hcl_parsed.list {
@@ -65,7 +75,12 @@ pub fn read_hcl(path: &String) {
             kind: kind.clone(),
             runner: runner.clone(),
         }
-        .create(&item.script, &Some(name.clone()), &item.get_watch_path(), true);
+        .create(
+            &item.script,
+            &Some(name.clone()),
+            &item.get_watch_path(),
+            true,
+        );
 
         println!("{} Imported {kind}process {name}", *helpers::SUCCESS);
 
@@ -84,8 +99,13 @@ pub fn read_hcl(path: &String) {
         }
     }
 
-    servers.iter().for_each(|server| super::Internal::list(&string!("default"), &server));
-    println!("{} Applied startProcess to imported items", *helpers::SUCCESS);
+    servers
+        .iter()
+        .for_each(|server| super::Internal::list(&string!("default"), &server));
+    println!(
+        "{} Applied startProcess to imported items",
+        *helpers::SUCCESS
+    );
 }
 
 pub fn export_hcl(item: &Item, path: &Option<String>) {
@@ -99,10 +119,14 @@ pub fn export_hcl(item: &Item, path: &Option<String>) {
         let mut env_parsed = HashMap::new();
 
         let current_env: HashMap<String, String> = std::env::vars().collect();
-        let path = path.clone().unwrap_or(format!("{}.hcl", process.name.clone()));
+        let path = path
+            .clone()
+            .unwrap_or(format!("{}.hcl", process.name.clone()));
 
         if process.watch.enabled {
-            watch_parsed = Some(Watch { path: process.watch.path.clone() })
+            watch_parsed = Some(Watch {
+                path: process.watch.path.clone(),
+            })
         }
 
         for (key, value) in process.env.clone() {
@@ -127,13 +151,25 @@ pub fn export_hcl(item: &Item, path: &Option<String>) {
         let serialized = hcl::to_string(&data).unwrap();
 
         if Exists::check(&path).file() {
-            let mut file = OpenOptions::new().write(true).append(true).open(path.clone()).unwrap();
+            let mut file = OpenOptions::new()
+                .write(true)
+                .append(true)
+                .open(path.clone())
+                .unwrap();
             if let Err(err) = writeln!(file, "{}", serialized) {
-                crashln!("{} Error writing to file.\n{}", *helpers::FAIL, string!(err).white())
+                crashln!(
+                    "{} Error writing to file.\n{}",
+                    *helpers::FAIL,
+                    string!(err).white()
+                )
             }
         } else {
             if let Err(err) = fs::write(path.clone(), serialized) {
-                crashln!("{} Error writing file.\n{}", *helpers::FAIL, string!(err).white())
+                crashln!(
+                    "{} Error writing file.\n{}",
+                    *helpers::FAIL,
+                    string!(err).white()
+                )
             }
         }
 

--- a/src/cli/internal.rs
+++ b/src/cli/internal.rs
@@ -1,4 +1,5 @@
 use colored::Colorize;
+use futures::{StreamExt, stream::FuturesUnordered};
 use macros_rs::{crashln, string, ternary, then};
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use pmc::process::{MemoryInfo, unix::NativeProcess as Process};
@@ -7,23 +8,22 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::{runtime::Runtime, signal, sync::broadcast};
 use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
-use futures::{StreamExt, stream::FuturesUnordered};
 
 use pmc::{
     config, file,
     helpers::{self, ColoredString},
     log,
-    process::{http, ItemSingle, Runner, get_process_cpu_usage_percentage},
+    process::{ItemSingle, Runner, get_process_cpu_usage_percentage, http},
 };
 
 use tabled::{
+    Table, Tabled,
     settings::{
+        Color, Modify, Rotate, Width,
         object::{Columns, Rows},
         style::{BorderColor, Style},
         themes::Colorization,
-        Color, Modify, Rotate, Width,
     },
-    Table, Tabled,
 };
 
 pub struct Internal<'i> {
@@ -55,10 +55,23 @@ fn ws_scheme(address: &str) -> String {
 
 fn local_ws_url(id: usize, kind: &str, lines: usize) -> String {
     let cfg = config::read();
-    let host = ternary!(cfg.daemon.web.address == "0.0.0.0", string!("127.0.0.1"), cfg.daemon.web.address.clone());
+    let host = ternary!(
+        cfg.daemon.web.address == "0.0.0.0",
+        string!("127.0.0.1"),
+        cfg.daemon.web.address.clone()
+    );
     let base = cfg.get_path().trim_end_matches('/').to_string();
-    let token = cfg.daemon.web.secure.as_ref().filter(|s| s.enabled).map(|s| s.token.clone());
-    let mut url = format!("ws://{}:{}{}/process/{id}/logs/{kind}/ws?tail={lines}", host, cfg.daemon.web.port, base);
+    let token = cfg
+        .daemon
+        .web
+        .secure
+        .as_ref()
+        .filter(|s| s.enabled)
+        .map(|s| s.token.clone());
+    let mut url = format!(
+        "ws://{}:{}{}/process/{id}/logs/{kind}/ws?tail={lines}",
+        host, cfg.daemon.web.port, base
+    );
 
     if let Some(token) = token {
         url.push_str(&format!("&token={token}"));
@@ -67,7 +80,13 @@ fn local_ws_url(id: usize, kind: &str, lines: usize) -> String {
     url
 }
 
-fn remote_ws_url(address: &str, token: &Option<String>, id: usize, kind: &str, lines: usize) -> String {
+fn remote_ws_url(
+    address: &str,
+    token: &Option<String>,
+    id: usize,
+    kind: &str,
+    lines: usize,
+) -> String {
     let base = address.trim_end_matches('/');
     let mut url = ws_scheme(base);
     url.push_str(&format!("/process/{id}/logs/{kind}/ws?tail={lines}"));
@@ -80,19 +99,36 @@ fn remote_ws_url(address: &str, token: &Option<String>, id: usize, kind: &str, l
 }
 
 fn print_snapshot(id: usize, item_name: &str, kind: &str, path: &str, lines: &[String]) {
-    println!("{}", format!("\n{path} last {} lines ({kind}):", lines.len()).bright_black());
+    println!(
+        "{}",
+        format!("\n{path} last {} lines ({kind}):", lines.len()).bright_black()
+    );
     let color = ternary!(kind == "out" || kind == "stdout", "green", "red");
     for line in lines {
-        println!("{} {}", format!("{}|{}|{kind} |", id, item_name).color(color), line);
+        println!(
+            "{} {}",
+            format!("{}|{}|{kind} |", id, item_name).color(color),
+            line
+        );
     }
 }
 
 fn print_line(id: usize, item_name: &str, kind: &str, line: &str) {
     let color = ternary!(kind == "out" || kind == "stdout", "green", "red");
-    println!("{} {}", format!("{}|{}|{kind} |", id, item_name).color(color), line);
+    println!(
+        "{} {}",
+        format!("{}|{}|{kind} |", id, item_name).color(color),
+        line
+    );
 }
 
-async fn stream_ws_once(url: String, id: usize, item_name: String, kind: String, mut shutdown: broadcast::Receiver<()>) -> anyhow::Result<()> {
+async fn stream_ws_once(
+    url: String,
+    id: usize,
+    item_name: String,
+    kind: String,
+    mut shutdown: broadcast::Receiver<()>,
+) -> anyhow::Result<()> {
     let (mut ws, _) = connect_async(url).await?;
 
     loop {
@@ -137,12 +173,22 @@ async fn stream_ws_once(url: String, id: usize, item_name: String, kind: String,
     Ok(())
 }
 
-async fn stream_ws_multi(urls: Vec<(String, String)>, id: usize, item_name: String) -> anyhow::Result<()> {
+async fn stream_ws_multi(
+    urls: Vec<(String, String)>,
+    id: usize,
+    item_name: String,
+) -> anyhow::Result<()> {
     let (tx, _) = broadcast::channel(2);
     let mut tasks = FuturesUnordered::new();
 
     for (kind, url) in urls {
-        tasks.push(tokio::spawn(stream_ws_once(url, id, item_name.clone(), kind, tx.subscribe())));
+        tasks.push(tokio::spawn(stream_ws_once(
+            url,
+            id,
+            item_name.clone(),
+            kind,
+            tx.subscribe(),
+        )));
     }
 
     let joiner = async move {
@@ -161,9 +207,14 @@ async fn stream_ws_multi(urls: Vec<(String, String)>, id: usize, item_name: Stri
     Ok(())
 }
 
-
 impl<'i> Internal<'i> {
-    pub fn create(mut self, script: &String, name: &Option<String>, watch: &Option<String>, silent: bool) -> Runner {
+    pub fn create(
+        mut self,
+        script: &String,
+        name: &Option<String>,
+        watch: &Option<String>,
+        silent: bool,
+    ) -> Runner {
         let config = config::read();
         let name = match name {
             Some(name) => string!(name),
@@ -187,21 +238,54 @@ impl<'i> Internal<'i> {
             if let Some(server) = servers.get(self.server_name) {
                 match Runner::connect(self.server_name.into(), server.get(), false) {
                     Some(mut remote) => remote.start(&name, script, file::cwd(), watch),
-                    None => crashln!("{} Failed to connect (name={}, address={})", *helpers::FAIL, self.server_name, server.address),
+                    None => crashln!(
+                        "{} Failed to connect (name={}, address={})",
+                        *helpers::FAIL,
+                        self.server_name,
+                        server.address
+                    ),
                 };
             } else {
-                crashln!("{} Server '{}' does not exist", *helpers::FAIL, self.server_name,)
+                crashln!(
+                    "{} Server '{}' does not exist",
+                    *helpers::FAIL,
+                    self.server_name,
+                )
             };
         }
 
-        then!(!silent, println!("{} Creating {}process with ({name})", *helpers::SUCCESS, self.kind));
-        then!(!silent, println!("{} {}Created ({name}) ✓", *helpers::SUCCESS, self.kind));
+        then!(
+            !silent,
+            println!(
+                "{} Creating {}process with ({name})",
+                *helpers::SUCCESS,
+                self.kind
+            )
+        );
+        then!(
+            !silent,
+            println!("{} {}Created ({name}) ✓", *helpers::SUCCESS, self.kind)
+        );
 
         return self.runner;
     }
 
-    pub fn restart(mut self, name: &Option<String>, watch: &Option<String>, reset_env: bool, silent: bool) -> Runner {
-        then!(!silent, println!("{} Applying {}action restartProcess on ({})", *helpers::SUCCESS, self.kind, self.id));
+    pub fn restart(
+        mut self,
+        name: &Option<String>,
+        watch: &Option<String>,
+        reset_env: bool,
+        silent: bool,
+    ) -> Runner {
+        then!(
+            !silent,
+            println!(
+                "{} Applying {}action restartProcess on ({})",
+                *helpers::SUCCESS,
+                self.kind,
+                self.id
+            )
+        );
 
         if matches!(self.server_name, "internal" | "local") {
             let mut item = self.runner.get(self.id);
@@ -213,7 +297,8 @@ impl<'i> Internal<'i> {
 
             then!(reset_env, item.clear_env());
 
-            name.as_ref().map(|n| item.rename(n.trim().replace("\n", "")));
+            name.as_ref()
+                .map(|n| item.rename(n.trim().replace("\n", "")));
             item.restart();
 
             self.runner = item.get_runner().clone();
@@ -229,18 +314,33 @@ impl<'i> Internal<'i> {
 
                         then!(reset_env, item.clear_env());
 
-                        name.as_ref().map(|n| item.rename(n.trim().replace("\n", "")));
+                        name.as_ref()
+                            .map(|n| item.rename(n.trim().replace("\n", "")));
                         item.restart();
                     }
-                    None => crashln!("{} Failed to connect (name={}, address={})", *helpers::FAIL, self.server_name, server.address),
+                    None => crashln!(
+                        "{} Failed to connect (name={}, address={})",
+                        *helpers::FAIL,
+                        self.server_name,
+                        server.address
+                    ),
                 }
             } else {
-                crashln!("{} Server '{}' does not exist", *helpers::FAIL, self.server_name)
+                crashln!(
+                    "{} Server '{}' does not exist",
+                    *helpers::FAIL,
+                    self.server_name
+                )
             };
         }
 
         if !silent {
-            println!("{} Restarted {}({}) ✓", *helpers::SUCCESS, self.kind, self.id);
+            println!(
+                "{} Restarted {}({}) ✓",
+                *helpers::SUCCESS,
+                self.kind,
+                self.id
+            );
             log!("process started (id={})", self.id);
         }
 
@@ -248,7 +348,15 @@ impl<'i> Internal<'i> {
     }
 
     pub fn stop(mut self, silent: bool) -> Runner {
-        then!(!silent, println!("{} Applying {}action stopProcess on ({})", *helpers::SUCCESS, self.kind, self.id));
+        then!(
+            !silent,
+            println!(
+                "{} Applying {}action stopProcess on ({})",
+                *helpers::SUCCESS,
+                self.kind,
+                self.id
+            )
+        );
 
         if !matches!(self.server_name, "internal" | "local") {
             let Some(servers) = config::servers().servers else {
@@ -258,10 +366,19 @@ impl<'i> Internal<'i> {
             if let Some(server) = servers.get(self.server_name) {
                 self.runner = match Runner::connect(self.server_name.into(), server.get(), false) {
                     Some(remote) => remote,
-                    None => crashln!("{} Failed to connect (name={}, address={})", *helpers::FAIL, self.server_name, server.address),
+                    None => crashln!(
+                        "{} Failed to connect (name={}, address={})",
+                        *helpers::FAIL,
+                        self.server_name,
+                        server.address
+                    ),
                 };
             } else {
-                crashln!("{} Server '{}' does not exist", *helpers::FAIL, self.server_name)
+                crashln!(
+                    "{} Server '{}' does not exist",
+                    *helpers::FAIL,
+                    self.server_name
+                )
             };
         }
 
@@ -278,7 +395,12 @@ impl<'i> Internal<'i> {
     }
 
     pub fn remove(mut self) {
-        println!("{} Applying {}action removeProcess on ({})", *helpers::SUCCESS, self.kind, self.id);
+        println!(
+            "{} Applying {}action removeProcess on ({})",
+            *helpers::SUCCESS,
+            self.kind,
+            self.id
+        );
 
         if !matches!(self.server_name, "internal" | "local") {
             let Some(servers) = config::servers().servers else {
@@ -288,10 +410,19 @@ impl<'i> Internal<'i> {
             if let Some(server) = servers.get(self.server_name) {
                 self.runner = match Runner::connect(self.server_name.into(), server.get(), false) {
                     Some(remote) => remote,
-                    None => crashln!("{} Failed to remove (name={}, address={})", *helpers::FAIL, self.server_name, server.address),
+                    None => crashln!(
+                        "{} Failed to remove (name={}, address={})",
+                        *helpers::FAIL,
+                        self.server_name,
+                        server.address
+                    ),
                 };
             } else {
-                crashln!("{} Server '{}' does not exist", *helpers::FAIL, self.server_name)
+                crashln!(
+                    "{} Server '{}' does not exist",
+                    *helpers::FAIL,
+                    self.server_name
+                )
             };
         }
 
@@ -301,7 +432,12 @@ impl<'i> Internal<'i> {
     }
 
     pub fn flush(&mut self) {
-        println!("{} Applying {}action flushLogs on ({})", *helpers::SUCCESS, self.kind, self.id);
+        println!(
+            "{} Applying {}action flushLogs on ({})",
+            *helpers::SUCCESS,
+            self.kind,
+            self.id
+        );
 
         if !matches!(self.server_name, "internal" | "local") {
             let Some(servers) = config::servers().servers else {
@@ -311,15 +447,29 @@ impl<'i> Internal<'i> {
             if let Some(server) = servers.get(self.server_name) {
                 self.runner = match Runner::connect(self.server_name.into(), server.get(), false) {
                     Some(remote) => remote,
-                    None => crashln!("{} Failed to remove (name={}, address={})", *helpers::FAIL, self.server_name, server.address),
+                    None => crashln!(
+                        "{} Failed to remove (name={}, address={})",
+                        *helpers::FAIL,
+                        self.server_name,
+                        server.address
+                    ),
                 };
             } else {
-                crashln!("{} Server '{}' does not exist", *helpers::FAIL, self.server_name)
+                crashln!(
+                    "{} Server '{}' does not exist",
+                    *helpers::FAIL,
+                    self.server_name
+                )
             };
         }
 
         self.runner.flush(self.id);
-        println!("{} Flushed Logs {}({}) ✓", *helpers::SUCCESS, self.kind, self.id);
+        println!(
+            "{} Flushed Logs {}({}) ✓",
+            *helpers::SUCCESS,
+            self.kind,
+            self.id
+        );
         log!("process logs cleaned (id={})", self.id);
     }
 
@@ -389,9 +539,25 @@ impl<'i> Internal<'i> {
                     "raw" => println!("{:?}", data[0]),
                     "json" => println!("{json}"),
                     _ => {
-                        println!("{}\n{table}\n", format!("Describing {}process with id ({})", self.kind, self.id).on_bright_white().black());
-                        println!(" {}", format!("Use `pmc logs {} [--lines <num>]` to display logs", self.id).white());
-                        println!(" {}", format!("Use `pmc env {}`  to display environment variables", self.id).white());
+                        println!(
+                            "{}\n{table}\n",
+                            format!("Describing {}process with id ({})", self.kind, self.id)
+                                .on_bright_white()
+                                .black()
+                        );
+                        println!(
+                            " {}",
+                            format!("Use `pmc logs {} [--lines <num>]` to display logs", self.id)
+                                .white()
+                        );
+                        println!(
+                            " {}",
+                            format!(
+                                "Use `pmc env {}`  to display environment variables",
+                                self.id
+                            )
+                            .white()
+                        );
                     }
                 };
             };
@@ -406,8 +572,14 @@ impl<'i> Internal<'i> {
                 let mut memory_usage: Option<MemoryInfo> = None;
                 let mut cpu_percent: Option<f64> = None;
 
-                let path = file::make_relative(&item.path, &home).to_string_lossy().into_owned();
-                let children = if item.children.is_empty() { "none".to_string() } else { format!("{:?}", item.children) };
+                let path = file::make_relative(&item.path, &home)
+                    .to_string_lossy()
+                    .into_owned();
+                let children = if item.children.is_empty() {
+                    "none".to_string()
+                } else {
+                    format!("{:?}", item.children)
+                };
 
                 if let Ok(process) = Process::new(item.pid as u32) {
                     memory_usage = process.memory_info().ok().map(MemoryInfo::from);
@@ -447,10 +619,27 @@ impl<'i> Internal<'i> {
                     log_error: item.logs().error,
                     status: ColoredString(status),
                     pid: ternary!(item.running, format!("{}", item.pid), string!("n/a")),
-                    command: format!("{} {} '{}'", config.shell, config.args.join(" "), item.script),
-                    hash: ternary!(item.watch.enabled, format!("{}  ", item.watch.hash), string!("none  ")),
-                    watch: ternary!(item.watch.enabled, format!("{path}/{}  ", item.watch.path), string!("disabled  ")),
-                    uptime: ternary!(item.running, format!("{}", helpers::format_duration(item.started)), string!("none")),
+                    command: format!(
+                        "{} {} '{}'",
+                        config.shell,
+                        config.args.join(" "),
+                        item.script
+                    ),
+                    hash: ternary!(
+                        item.watch.enabled,
+                        format!("{}  ", item.watch.hash),
+                        string!("none  ")
+                    ),
+                    watch: ternary!(
+                        item.watch.enabled,
+                        format!("{path}/{}  ", item.watch.path),
+                        string!("disabled  ")
+                    ),
+                    uptime: ternary!(
+                        item.running,
+                        format!("{}", helpers::format_duration(item.started)),
+                        string!("none")
+                    ),
                 }];
 
                 render_info(data)
@@ -466,10 +655,19 @@ impl<'i> Internal<'i> {
             if let Some(server) = servers.get(self.server_name) {
                 data = match Runner::connect(self.server_name.into(), server.get(), false) {
                     Some(mut remote) => (remote.process(self.id).clone(), remote),
-                    None => crashln!("{} Failed to connect (name={}, address={})", *helpers::FAIL, self.server_name, server.address),
+                    None => crashln!(
+                        "{} Failed to connect (name={}, address={})",
+                        *helpers::FAIL,
+                        self.server_name,
+                        server.address
+                    ),
                 };
             } else {
-                crashln!("{} Server '{}' does not exist", *helpers::FAIL, self.server_name)
+                crashln!(
+                    "{} Server '{}' does not exist",
+                    *helpers::FAIL,
+                    self.server_name
+                )
             };
 
             let (item, remote) = data;
@@ -490,7 +688,11 @@ impl<'i> Internal<'i> {
 
             if let Ok(info) = info {
                 let stats = info.json::<ItemSingle>().unwrap().stats;
-                let children = if item.children.is_empty() { "none".to_string() } else { format!("{:?}", item.children) };
+                let children = if item.children.is_empty() {
+                    "none".to_string()
+                } else {
+                    format!("{:?}", item.children)
+                };
 
                 let cpu_percent = match stats.cpu_percent {
                     Some(percent) => format!("{percent:.2}%"),
@@ -511,13 +713,34 @@ impl<'i> Internal<'i> {
                     status: status.into(),
                     restarts: item.restarts,
                     name: item.name.clone(),
-                    pid: ternary!(item.running, format!("{pid}", pid = item.pid), string!("n/a")),
+                    pid: ternary!(
+                        item.running,
+                        format!("{pid}", pid = item.pid),
+                        string!("n/a")
+                    ),
                     log_out: format!("{}/{}-out.log", remote.config.log_path, item.name),
                     log_error: format!("{}/{}-error.log", remote.config.log_path, item.name),
-                    hash: ternary!(item.watch.enabled, format!("{}  ", item.watch.hash), string!("none  ")),
-                    command: format!("{} {} '{}'", remote.config.shell, remote.config.args.join(" "), item.script),
-                    watch: ternary!(item.watch.enabled, format!("{path}/{}  ", item.watch.path), string!("disabled  ")),
-                    uptime: ternary!(item.running, format!("{}", helpers::format_duration(item.started)), string!("none")),
+                    hash: ternary!(
+                        item.watch.enabled,
+                        format!("{}  ", item.watch.hash),
+                        string!("none  ")
+                    ),
+                    command: format!(
+                        "{} {} '{}'",
+                        remote.config.shell,
+                        remote.config.args.join(" "),
+                        item.script
+                    ),
+                    watch: ternary!(
+                        item.watch.enabled,
+                        format!("{path}/{}  ", item.watch.path),
+                        string!("disabled  ")
+                    ),
+                    uptime: ternary!(
+                        item.running,
+                        format!("{}", helpers::format_duration(item.started)),
+                        string!("none")
+                    ),
                 }];
 
                 render_info(data)
@@ -537,22 +760,40 @@ impl<'i> Internal<'i> {
             if let Some(server) = servers.get(self.server_name) {
                 self.runner = match Runner::connect(self.server_name.into(), server.get(), false) {
                     Some(remote) => remote,
-                    None => crashln!("{} Failed to connect (name={}, address={})", *helpers::FAIL, self.server_name, server.address),
+                    None => crashln!(
+                        "{} Failed to connect (name={}, address={})",
+                        *helpers::FAIL,
+                        self.server_name,
+                        server.address
+                    ),
                 };
             } else {
-                crashln!("{} Server '{}' does not exist", *helpers::FAIL, self.server_name)
+                crashln!(
+                    "{} Server '{}' does not exist",
+                    *helpers::FAIL,
+                    self.server_name
+                )
             };
 
-            let item = self.runner.info(self.id).unwrap_or_else(|| crashln!("{} Process ({}) not found", *helpers::FAIL, self.id));
+            let item = self
+                .runner
+                .info(self.id)
+                .unwrap_or_else(|| crashln!("{} Process ({}) not found", *helpers::FAIL, self.id));
             if let Some(remote) = &self.runner.remote {
                 for kind in ["error", "out"] {
-                    urls.push((kind.to_string(), remote_ws_url(remote.address(), remote.token(), self.id, kind, tail)));
+                    urls.push((
+                        kind.to_string(),
+                        remote_ws_url(remote.address(), remote.token(), self.id, kind, tail),
+                    ));
                 }
             }
 
             Some(item.name.clone())
         } else {
-            let item = self.runner.info(self.id).unwrap_or_else(|| crashln!("{} Process ({}) not found", *helpers::FAIL, self.id));
+            let item = self
+                .runner
+                .info(self.id)
+                .unwrap_or_else(|| crashln!("{} Process ({}) not found", *helpers::FAIL, self.id));
 
             for kind in ["error", "out"] {
                 urls.push((kind.to_string(), local_ws_url(self.id, kind, tail)));
@@ -564,13 +805,23 @@ impl<'i> Internal<'i> {
         if !urls.is_empty() {
             println!(
                 "{}",
-                format!("Streaming last {tail} lines for {}process [{}] (Ctrl+C to stop)", self.kind, self.id).yellow()
+                format!(
+                    "Streaming last {tail} lines for {}process [{}] (Ctrl+C to stop)",
+                    self.kind, self.id
+                )
+                .yellow()
             );
 
             let runtime = Runtime::new();
-            if let Err(err) = runtime
-                .expect("Failed to create tokio runtime")
-                .block_on(stream_ws_multi(urls, self.id, item_name.clone().unwrap_or_default())) {
+            if let Err(err) =
+                runtime
+                    .expect("Failed to create tokio runtime")
+                    .block_on(stream_ws_multi(
+                        urls,
+                        self.id,
+                        item_name.clone().unwrap_or_default(),
+                    ))
+            {
                 println!("{} WebSocket streaming failed: {err}", *helpers::FAIL);
             } else {
                 return;
@@ -579,7 +830,10 @@ impl<'i> Internal<'i> {
 
         // fallback to existing behavior
         if !matches!(self.server_name, "internal" | "local") {
-            let item = self.runner.info(self.id).unwrap_or_else(|| crashln!("{} Process ({}) not found", *helpers::FAIL, self.id));
+            let item = self
+                .runner
+                .info(self.id)
+                .unwrap_or_else(|| crashln!("{} Process ({}) not found", *helpers::FAIL, self.id));
             println!(
                 "{}",
                 format!("Showing last {lines} lines for {}process [{}] (change the value with --lines option)", self.kind, self.id).yellow()
@@ -598,7 +852,10 @@ impl<'i> Internal<'i> {
                 }
             }
         } else {
-            let item = self.runner.info(self.id).unwrap_or_else(|| crashln!("{} Process ({}) not found", *helpers::FAIL, self.id));
+            let item = self
+                .runner
+                .info(self.id)
+                .unwrap_or_else(|| crashln!("{} Process ({}) not found", *helpers::FAIL, self.id));
             println!(
                 "{}",
                 format!("Showing last {lines} lines for {}process [{}] (change the value with --lines option)", self.kind, self.id).yellow()
@@ -610,7 +867,10 @@ impl<'i> Internal<'i> {
     }
 
     pub fn env(mut self) {
-        println!("{}", format!("Showing env for {}process {}:\n", self.kind, self.id).bright_yellow());
+        println!(
+            "{}",
+            format!("Showing env for {}process {}:\n", self.kind, self.id).bright_yellow()
+        );
 
         if !matches!(self.server_name, "internal" | "local") {
             let Some(servers) = config::servers().servers else {
@@ -620,15 +880,26 @@ impl<'i> Internal<'i> {
             if let Some(server) = servers.get(self.server_name) {
                 self.runner = match Runner::connect(self.server_name.into(), server.get(), false) {
                     Some(remote) => remote,
-                    None => crashln!("{} Failed to connect (name={}, address={})", *helpers::FAIL, self.server_name, server.address),
+                    None => crashln!(
+                        "{} Failed to connect (name={}, address={})",
+                        *helpers::FAIL,
+                        self.server_name,
+                        server.address
+                    ),
                 };
             } else {
-                crashln!("{} Server '{}' does not exist", *helpers::FAIL, self.server_name)
+                crashln!(
+                    "{} Server '{}' does not exist",
+                    *helpers::FAIL,
+                    self.server_name
+                )
             };
         }
 
         let item = self.runner.process(self.id);
-        item.env.iter().for_each(|(key, value)| println!("{}: {}", key, value.green()));
+        item.env
+            .iter()
+            .for_each(|(key, value)| println!("{}: {}", key, value.green()));
     }
 
     pub fn save(server_name: &String) {
@@ -660,7 +931,10 @@ impl<'i> Internal<'i> {
             }
         });
 
-        println!("{} Restored process statuses from dumpfile", *helpers::SUCCESS);
+        println!(
+            "{} Restored process statuses from dumpfile",
+            *helpers::SUCCESS
+        );
         Internal::list(&string!("default"), &list_name);
     }
 
@@ -684,7 +958,10 @@ impl<'i> Internal<'i> {
             }
 
             impl serde::Serialize for ProcessItem {
-                fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                fn serialize<S: serde::Serializer>(
+                    &self,
+                    serializer: S,
+                ) -> Result<S::Ok, S::Error> {
                     let trimmed_json = json!({
                         "cpu": &self.cpu.trim(),
                         "mem": &self.mem.trim(),
@@ -711,7 +988,10 @@ impl<'i> Internal<'i> {
                         let mut usage_internals: (Option<f64>, Option<MemoryInfo>) = (None, None);
 
                         if let Ok(process) = Process::new(item.pid as u32) {
-                            usage_internals = (Some(get_process_cpu_usage_percentage(item.pid as i64)), process.memory_info().ok().map(MemoryInfo::from));
+                            usage_internals = (
+                                Some(get_process_cpu_usage_percentage(item.pid as i64)),
+                                process.memory_info().ok().map(MemoryInfo::from),
+                            );
                         }
 
                         cpu_percent = match usage_internals.0 {
@@ -760,8 +1040,16 @@ impl<'i> Internal<'i> {
                         restarts: format!("{}  ", item.restarts),
                         name: format!("{}   ", item.name.clone()),
                         pid: ternary!(item.running, format!("{}  ", item.pid), string!("n/a  ")),
-                        watch: ternary!(item.watch.enabled, format!("{}  ", item.watch.path), string!("disabled  ")),
-                        uptime: ternary!(item.running, format!("{}  ", helpers::format_duration(item.started)), string!("none  ")),
+                        watch: ternary!(
+                            item.watch.enabled,
+                            format!("{}  ", item.watch.path),
+                            string!("disabled  ")
+                        ),
+                        uptime: ternary!(
+                            item.running,
+                            format!("{}  ", helpers::format_duration(item.started)),
+                            string!("none  ")
+                        ),
                     });
                 }
 
@@ -789,7 +1077,11 @@ impl<'i> Internal<'i> {
             if let Some(server) = servers.get(server_name) {
                 match Runner::connect(server_name.clone(), server.get(), true) {
                     Some(mut remote) => render_list(&mut remote, false),
-                    None => println!("{} Failed to fetch (name={server_name}, address={})", *helpers::FAIL, server.address),
+                    None => println!(
+                        "{} Failed to fetch (name={server_name}, address={})",
+                        *helpers::FAIL,
+                        server.address
+                    ),
                 }
             } else {
                 if matches!(&**server_name, "internal" | "all" | "global" | "local") {
@@ -813,9 +1105,14 @@ impl<'i> Internal<'i> {
 
             if !failed.is_empty() {
                 println!("{} Failed servers:", *helpers::FAIL);
-                failed
-                    .iter()
-                    .for_each(|server| println!(" {} {} {}", "-".yellow(), format!("{}", server.0), format!("[{}]", server.1).white()));
+                failed.iter().for_each(|server| {
+                    println!(
+                        " {} {} {}",
+                        "-".yellow(),
+                        format!("{}", server.0),
+                        format!("[{}]", server.1).white()
+                    )
+                });
             }
         } else {
             render_list(&mut Runner::new(), true);

--- a/src/cli/internal.rs
+++ b/src/cli/internal.rs
@@ -297,7 +297,9 @@ impl<'i> Internal<'i> {
 
             then!(reset_env, item.clear_env());
 
-            if let Some(n) = name.as_ref() { item.rename(n.trim().replace("\n", "")) }
+            if let Some(n) = name.as_ref() {
+                item.rename(n.trim().replace("\n", ""))
+            }
             item.restart();
 
             self.runner = item.get_runner().clone();
@@ -313,7 +315,9 @@ impl<'i> Internal<'i> {
 
                         then!(reset_env, item.clear_env());
 
-                        if let Some(n) = name.as_ref() { item.rename(n.trim().replace("\n", "")) }
+                        if let Some(n) = name.as_ref() {
+                            item.rename(n.trim().replace("\n", ""))
+                        }
                         item.restart();
                     }
                     None => crashln!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,11 +17,11 @@ pub(crate) fn format(server_name: &String) -> (String, String) {
         "remote "
     )
     .to_string();
-    return (kind, server_name.to_string());
+    (kind, server_name.to_string())
 }
 
 pub fn get_version(short: bool) -> String {
-    return match short {
+    match short {
         true => format!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
         false => match env!("GIT_HASH") {
             "" => format!(
@@ -37,7 +37,7 @@ pub fn get_version(short: bool) -> String {
                 env!("PROFILE")
             ),
         },
-    };
+    }
 }
 
 pub fn start(
@@ -50,10 +50,7 @@ pub fn start(
     let mut runner = Runner::new();
     let (kind, list_name) = format(server_name);
 
-    let arg = match args.get_string() {
-        Some(arg) => arg,
-        None => "",
-    };
+    let arg = args.get_string().unwrap_or_default();
 
     if arg == "all" {
         println!(
@@ -85,7 +82,7 @@ pub fn start(
                 }
                 .restart(name, watch, *reset_env, false);
             }
-            Args::Script(script) => match runner.find(&script, server_name) {
+            Args::Script(script) => match runner.find(script, server_name) {
                 Some(id) => {
                     Internal {
                         id,
@@ -115,10 +112,7 @@ pub fn stop(item: &Item, server_name: &String) {
     let mut runner: Runner = Runner::new();
     let (kind, list_name) = format(server_name);
 
-    let arg = match item.get_string() {
-        Some(arg) => arg,
-        None => "",
-    };
+    let arg = item.get_string().unwrap_or_default();
 
     if arg == "all" {
         println!("{} Applying {kind}action stopAllProcess", *helpers::SUCCESS);
@@ -147,7 +141,7 @@ pub fn stop(item: &Item, server_name: &String) {
                 }
                 .stop(false);
             }
-            Item::Name(name) => match runner.find(&name, server_name) {
+            Item::Name(name) => match runner.find(name, server_name) {
                 Some(id) => {
                     Internal {
                         id,
@@ -177,7 +171,7 @@ pub fn remove(item: &Item, server_name: &String) {
             kind,
         }
         .remove(),
-        Item::Name(name) => match runner.find(&name, server_name) {
+        Item::Name(name) => match runner.find(name, server_name) {
             Some(id) => Internal {
                 id,
                 runner,
@@ -204,7 +198,7 @@ pub fn info(item: &Item, format: &String, server_name: &String) {
             kind,
         }
         .info(format),
-        Item::Name(name) => match runner.find(&name, server_name) {
+        Item::Name(name) => match runner.find(name, server_name) {
             Some(id) => Internal {
                 id,
                 runner,
@@ -229,7 +223,7 @@ pub fn logs(item: &Item, lines: &usize, server_name: &String) {
             kind,
         }
         .logs(lines),
-        Item::Name(name) => match runner.find(&name, server_name) {
+        Item::Name(name) => match runner.find(name, server_name) {
             Some(id) => Internal {
                 id,
                 runner,
@@ -255,7 +249,7 @@ pub fn env(item: &Item, server_name: &String) {
             kind,
         }
         .env(),
-        Item::Name(name) => match runner.find(&name, server_name) {
+        Item::Name(name) => match runner.find(name, server_name) {
             Some(id) => Internal {
                 id,
                 runner,
@@ -280,7 +274,7 @@ pub fn flush(item: &Item, server_name: &String) {
             kind,
         }
         .flush(),
-        Item::Name(name) => match runner.find(&name, server_name) {
+        Item::Name(name) => match runner.find(name, server_name) {
             Some(id) => Internal {
                 id,
                 runner,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,7 +11,12 @@ use pmc::{helpers, process::Runner};
 use std::env;
 
 pub(crate) fn format(server_name: &String) -> (String, String) {
-    let kind = ternary!(matches!(&**server_name, "internal" | "local"), "", "remote ").to_string();
+    let kind = ternary!(
+        matches!(&**server_name, "internal" | "local"),
+        "",
+        "remote "
+    )
+    .to_string();
     return (kind, server_name.to_string());
 }
 
@@ -19,13 +24,29 @@ pub fn get_version(short: bool) -> String {
     return match short {
         true => format!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
         false => match env!("GIT_HASH") {
-            "" => format!("{} ({}) [{}]", env!("CARGO_PKG_VERSION"), env!("BUILD_DATE"), env!("PROFILE")),
-            hash => format!("{} ({} {hash}) [{}]", env!("CARGO_PKG_VERSION"), env!("BUILD_DATE"), env!("PROFILE")),
+            "" => format!(
+                "{} ({}) [{}]",
+                env!("CARGO_PKG_VERSION"),
+                env!("BUILD_DATE"),
+                env!("PROFILE")
+            ),
+            hash => format!(
+                "{} ({} {hash}) [{}]",
+                env!("CARGO_PKG_VERSION"),
+                env!("BUILD_DATE"),
+                env!("PROFILE")
+            ),
         },
     };
 }
 
-pub fn start(name: &Option<String>, args: &Args, watch: &Option<String>, reset_env: &bool, server_name: &String) {
+pub fn start(
+    name: &Option<String>,
+    args: &Args,
+    watch: &Option<String>,
+    reset_env: &bool,
+    server_name: &String,
+) {
     let mut runner = Runner::new();
     let (kind, list_name) = format(server_name);
 
@@ -35,7 +56,10 @@ pub fn start(name: &Option<String>, args: &Args, watch: &Option<String>, reset_e
     };
 
     if arg == "all" {
-        println!("{} Applying {kind}action startAllProcess", *helpers::SUCCESS);
+        println!(
+            "{} Applying {kind}action startAllProcess",
+            *helpers::SUCCESS
+        );
 
         let largest = runner.size();
         match largest {
@@ -53,14 +77,32 @@ pub fn start(name: &Option<String>, args: &Args, watch: &Option<String>, reset_e
     } else {
         match args {
             Args::Id(id) => {
-                Internal { id: *id, runner, server_name, kind }.restart(name, watch, *reset_env, false);
+                Internal {
+                    id: *id,
+                    runner,
+                    server_name,
+                    kind,
+                }
+                .restart(name, watch, *reset_env, false);
             }
             Args::Script(script) => match runner.find(&script, server_name) {
                 Some(id) => {
-                    Internal { id, runner, server_name, kind }.restart(name, watch, *reset_env, false);
+                    Internal {
+                        id,
+                        runner,
+                        server_name,
+                        kind,
+                    }
+                    .restart(name, watch, *reset_env, false);
                 }
                 None => {
-                    Internal { id: 0, runner, server_name, kind }.create(script, name, watch, false);
+                    Internal {
+                        id: 0,
+                        runner,
+                        server_name,
+                        kind,
+                    }
+                    .create(script, name, watch, false);
                 }
             },
         }
@@ -97,11 +139,23 @@ pub fn stop(item: &Item, server_name: &String) {
     } else {
         match item {
             Item::Id(id) => {
-                Internal { id: *id, runner, server_name, kind }.stop(false);
+                Internal {
+                    id: *id,
+                    runner,
+                    server_name,
+                    kind,
+                }
+                .stop(false);
             }
             Item::Name(name) => match runner.find(&name, server_name) {
                 Some(id) => {
-                    Internal { id, runner, server_name, kind }.stop(false);
+                    Internal {
+                        id,
+                        runner,
+                        server_name,
+                        kind,
+                    }
+                    .stop(false);
                 }
                 None => crashln!("{} Process ({name}) not found", *helpers::FAIL),
             },
@@ -116,9 +170,21 @@ pub fn remove(item: &Item, server_name: &String) {
     let (kind, _) = format(server_name);
 
     match item {
-        Item::Id(id) => Internal { id: *id, runner, server_name, kind }.remove(),
+        Item::Id(id) => Internal {
+            id: *id,
+            runner,
+            server_name,
+            kind,
+        }
+        .remove(),
         Item::Name(name) => match runner.find(&name, server_name) {
-            Some(id) => Internal { id, runner, server_name, kind }.remove(),
+            Some(id) => Internal {
+                id,
+                runner,
+                server_name,
+                kind,
+            }
+            .remove(),
             None => crashln!("{} Process ({name}) not found", *helpers::FAIL),
         },
     }
@@ -131,9 +197,21 @@ pub fn info(item: &Item, format: &String, server_name: &String) {
     let (kind, _) = self::format(server_name);
 
     match item {
-        Item::Id(id) => Internal { id: *id, runner, server_name, kind }.info(format),
+        Item::Id(id) => Internal {
+            id: *id,
+            runner,
+            server_name,
+            kind,
+        }
+        .info(format),
         Item::Name(name) => match runner.find(&name, server_name) {
-            Some(id) => Internal { id, runner, server_name, kind }.info(format),
+            Some(id) => Internal {
+                id,
+                runner,
+                server_name,
+                kind,
+            }
+            .info(format),
             None => crashln!("{} Process ({name}) not found", *helpers::FAIL),
         },
     }
@@ -144,9 +222,21 @@ pub fn logs(item: &Item, lines: &usize, server_name: &String) {
     let (kind, _) = format(server_name);
 
     match item {
-        Item::Id(id) => Internal { id: *id, runner, server_name, kind }.logs(lines),
+        Item::Id(id) => Internal {
+            id: *id,
+            runner,
+            server_name,
+            kind,
+        }
+        .logs(lines),
         Item::Name(name) => match runner.find(&name, server_name) {
-            Some(id) => Internal { id, runner, server_name, kind }.logs(lines),
+            Some(id) => Internal {
+                id,
+                runner,
+                server_name,
+                kind,
+            }
+            .logs(lines),
             None => crashln!("{} Process ({name}) not found", *helpers::FAIL),
         },
     }
@@ -158,9 +248,21 @@ pub fn env(item: &Item, server_name: &String) {
     let (kind, _) = format(server_name);
 
     match item {
-        Item::Id(id) => Internal { id: *id, runner, server_name, kind }.env(),
+        Item::Id(id) => Internal {
+            id: *id,
+            runner,
+            server_name,
+            kind,
+        }
+        .env(),
         Item::Name(name) => match runner.find(&name, server_name) {
-            Some(id) => Internal { id, runner, server_name, kind }.env(),
+            Some(id) => Internal {
+                id,
+                runner,
+                server_name,
+                kind,
+            }
+            .env(),
             None => crashln!("{} Process ({name}) not found", *helpers::FAIL),
         },
     }
@@ -171,9 +273,21 @@ pub fn flush(item: &Item, server_name: &String) {
     let (kind, _) = format(server_name);
 
     match item {
-        Item::Id(id) => Internal { id: *id, runner, server_name, kind }.flush(),
+        Item::Id(id) => Internal {
+            id: *id,
+            runner,
+            server_name,
+            kind,
+        }
+        .flush(),
         Item::Name(name) => match runner.find(&name, server_name) {
-            Some(id) => Internal { id, runner, server_name, kind }.flush(),
+            Some(id) => Internal {
+                id,
+                runner,
+                server_name,
+                kind,
+            }
+            .flush(),
             None => crashln!("{} Process ({name}) not found", *helpers::FAIL),
         },
     }

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -57,7 +57,7 @@ pub fn list(format: &String, log_level: Option<log::Level>) {
     let servers = config::servers()
         .servers
         .take()
-        .unwrap_or_else(BTreeMap::new);
+        .unwrap_or_default();
 
     let options: Vec<_> = servers
         .iter()
@@ -69,7 +69,7 @@ pub fn list(format: &String, log_level: Option<log::Level>) {
 
             ServerOption {
                 name: key.clone(),
-                formatted: format!("{} {}", format!("{key}").bright_yellow(), verbose.white()),
+                formatted: format!("{} {}", key.to_string().bright_yellow(), verbose.white()),
             }
         })
         .collect();
@@ -85,7 +85,7 @@ pub fn new() {
     let mut servers = config::servers()
         .servers
         .take()
-        .unwrap_or_else(BTreeMap::new);
+        .unwrap_or_default();
 
     match Text::new("Server Name:").prompt() {
         Ok(ans) => name = ans,
@@ -115,7 +115,7 @@ pub fn new() {
         Err(_) => crashln!("{}", "Canceled...".white()),
         Ok(false) => {}
         Ok(true) => {
-            if name == "" || address == "" {
+            if name.is_empty() || address.is_empty() {
                 crashln!("{} Failed to add new server", *helpers::FAIL)
             } else {
                 servers.insert(name, Server { address, token });
@@ -130,7 +130,7 @@ pub fn remove(name: &String) {
     let mut servers = config::servers()
         .servers
         .take()
-        .unwrap_or_else(BTreeMap::new);
+        .unwrap_or_default();
 
     if servers.contains_key(name) {
         match Confirm::new(&format!("Remove server {name}? (y/n)")).prompt() {
@@ -151,7 +151,7 @@ pub fn default(name: &Option<String>) {
     let servers = config::servers()
         .servers
         .take()
-        .unwrap_or_else(BTreeMap::new);
+        .unwrap_or_default();
 
     let name = match name {
         Some(name) => name.as_str(),

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -54,10 +54,7 @@ impl std::fmt::Display for ServerOption {
 }
 
 pub fn list(format: &String, log_level: Option<log::Level>) {
-    let servers = config::servers()
-        .servers
-        .take()
-        .unwrap_or_default();
+    let servers = config::servers().servers.take().unwrap_or_default();
 
     let options: Vec<_> = servers
         .iter()
@@ -82,10 +79,7 @@ pub fn list(format: &String, log_level: Option<log::Level>) {
 
 pub fn new() {
     let (name, address, token);
-    let mut servers = config::servers()
-        .servers
-        .take()
-        .unwrap_or_default();
+    let mut servers = config::servers().servers.take().unwrap_or_default();
 
     match Text::new("Server Name:").prompt() {
         Ok(ans) => name = ans,
@@ -127,10 +121,7 @@ pub fn new() {
 }
 
 pub fn remove(name: &String) {
-    let mut servers = config::servers()
-        .servers
-        .take()
-        .unwrap_or_default();
+    let mut servers = config::servers().servers.take().unwrap_or_default();
 
     if servers.contains_key(name) {
         match Confirm::new(&format!("Remove server {name}? (y/n)")).prompt() {
@@ -148,10 +139,7 @@ pub fn remove(name: &String) {
 }
 
 pub fn default(name: &Option<String>) {
-    let servers = config::servers()
-        .servers
-        .take()
-        .unwrap_or_default();
+    let servers = config::servers().servers.take().unwrap_or_default();
 
     let name = match name {
         Some(name) => name.as_str(),

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -17,13 +17,23 @@ fn save(servers: BTreeMap<String, Server>) {
             let path = path.display();
             let config_path = format!("{path}/.pmc/servers.toml");
 
-            let contents = match toml::to_string(&Servers { servers: Some(servers) }) {
+            let contents = match toml::to_string(&Servers {
+                servers: Some(servers),
+            }) {
                 Ok(contents) => contents,
-                Err(err) => crashln!("{} Cannot parse servers.\n{}", *helpers::FAIL, string!(err).white()),
+                Err(err) => crashln!(
+                    "{} Cannot parse servers.\n{}",
+                    *helpers::FAIL,
+                    string!(err).white()
+                ),
             };
 
             if let Err(err) = write(&config_path, contents) {
-                crashln!("{} Error writing servers.\n{}", *helpers::FAIL, string!(err).white())
+                crashln!(
+                    "{} Error writing servers.\n{}",
+                    *helpers::FAIL,
+                    string!(err).white()
+                )
             }
         }
         None => crashln!("{} Impossible to get your home directory", *helpers::FAIL),
@@ -38,11 +48,16 @@ struct ServerOption {
 
 impl std::fmt::Display for ServerOption {
     #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { std::fmt::Display::fmt(&self.formatted, f) }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.formatted, f)
+    }
 }
 
 pub fn list(format: &String, log_level: Option<log::Level>) {
-    let servers = config::servers().servers.take().unwrap_or_else(BTreeMap::new);
+    let servers = config::servers()
+        .servers
+        .take()
+        .unwrap_or_else(BTreeMap::new);
 
     let options: Vec<_> = servers
         .iter()
@@ -67,7 +82,10 @@ pub fn list(format: &String, log_level: Option<log::Level>) {
 
 pub fn new() {
     let (name, address, token);
-    let mut servers = config::servers().servers.take().unwrap_or_else(BTreeMap::new);
+    let mut servers = config::servers()
+        .servers
+        .take()
+        .unwrap_or_else(BTreeMap::new);
 
     match Text::new("Server Name:").prompt() {
         Ok(ans) => name = ans,
@@ -109,7 +127,10 @@ pub fn new() {
 }
 
 pub fn remove(name: &String) {
-    let mut servers = config::servers().servers.take().unwrap_or_else(BTreeMap::new);
+    let mut servers = config::servers()
+        .servers
+        .take()
+        .unwrap_or_else(BTreeMap::new);
 
     if servers.contains_key(name) {
         match Confirm::new(&format!("Remove server {name}? (y/n)")).prompt() {
@@ -127,7 +148,10 @@ pub fn remove(name: &String) {
 }
 
 pub fn default(name: &Option<String>) {
-    let servers = config::servers().servers.take().unwrap_or_else(BTreeMap::new);
+    let servers = config::servers()
+        .servers
+        .take()
+        .unwrap_or_else(BTreeMap::new);
 
     let name = match name {
         Some(name) => name.as_str(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,10 +23,16 @@ pub fn from(address: &str, token: Option<&str>) -> Result<RemoteConfig, anyhow::
     let mut headers = HeaderMap::new();
 
     if let Some(token) = token {
-        headers.insert("token", HeaderValue::from_static(Box::leak(Box::from(token))));
+        headers.insert(
+            "token",
+            HeaderValue::from_static(Box::leak(Box::from(token))),
+        );
     }
 
-    let response = client.get(fmtstr!("{address}/daemon/config")).headers(headers).send()?;
+    let response = client
+        .get(fmtstr!("{address}/daemon/config"))
+        .headers(headers)
+        .send()?;
     let json = response.json::<RemoteConfig>()?;
 
     Ok(json)
@@ -58,18 +64,29 @@ pub fn read() -> Config {
                             address: string!("0.0.0.0"),
                             path: None,
                             port: 5630,
-                            secure: Some(Secure { enabled: false, token: string!("") }),
+                            secure: Some(Secure {
+                                enabled: false,
+                                token: string!(""),
+                            }),
                         },
                     },
                 };
 
                 let contents = match toml::to_string(&config) {
                     Ok(contents) => contents,
-                    Err(err) => crashln!("{} Cannot parse config.\n{}", *helpers::FAIL, string!(err).white()),
+                    Err(err) => crashln!(
+                        "{} Cannot parse config.\n{}",
+                        *helpers::FAIL,
+                        string!(err).white()
+                    ),
                 };
 
                 if let Err(err) = write(&config_path, contents) {
-                    crashln!("{} Error writing config.\n{}", *helpers::FAIL, string!(err).white())
+                    crashln!(
+                        "{} Error writing config.\n{}",
+                        *helpers::FAIL,
+                        string!(err).white()
+                    )
                 }
                 log::info!("created config file");
             }
@@ -88,7 +105,11 @@ pub fn servers() -> Servers {
 
             if !Exists::check(&config_path).file() {
                 if let Err(err) = write(&config_path, "") {
-                    crashln!("{} Error writing servers.\n{}", *helpers::FAIL, string!(err).white())
+                    crashln!(
+                        "{} Error writing servers.\n{}",
+                        *helpers::FAIL,
+                        string!(err).white()
+                    )
                 }
             }
 
@@ -99,18 +120,33 @@ pub fn servers() -> Servers {
 }
 
 impl Config {
-    pub fn check_shell_absolute(&self) -> bool { Path::new(&self.runner.shell).is_absolute() }
+    pub fn check_shell_absolute(&self) -> bool {
+        Path::new(&self.runner.shell).is_absolute()
+    }
 
     pub fn get_address(&self) -> rocket::figment::Figment {
         let config_split: Vec<u8> = match self.daemon.web.address.as_str() {
             "localhost" => vec![127, 0, 0, 1],
-            _ => self.daemon.web.address.split('.').map(|part| part.parse().expect("Failed to parse address part")).collect(),
+            _ => self
+                .daemon
+                .web
+                .address
+                .split('.')
+                .map(|part| part.parse().expect("Failed to parse address part"))
+                .collect(),
         };
 
-        let ipv4_address: Ipv4Addr = Ipv4Addr::from([config_split[0], config_split[1], config_split[2], config_split[3]]);
+        let ipv4_address: Ipv4Addr = Ipv4Addr::from([
+            config_split[0],
+            config_split[1],
+            config_split[2],
+            config_split[3],
+        ]);
         let ip_address: IpAddr = IpAddr::from(ipv4_address);
 
-        rocket::Config::figment().merge(("port", self.daemon.web.port)).merge(("address", ip_address))
+        rocket::Config::figment()
+            .merge(("port", self.daemon.web.port))
+            .merge(("address", ip_address))
     }
 
     pub fn save(&self) {
@@ -121,11 +157,19 @@ impl Config {
 
                 let contents = match toml::to_string(&self) {
                     Ok(contents) => contents,
-                    Err(err) => crashln!("{} Cannot parse config.\n{}", *helpers::FAIL, string!(err).white()),
+                    Err(err) => crashln!(
+                        "{} Cannot parse config.\n{}",
+                        *helpers::FAIL,
+                        string!(err).white()
+                    ),
                 };
 
                 if let Err(err) = write(&config_path, contents) {
-                    crashln!("{} Error writing config.\n{}", *helpers::FAIL, string!(err).white())
+                    crashln!(
+                        "{} Error writing config.\n{}",
+                        *helpers::FAIL,
+                        string!(err).white()
+                    )
                 }
             }
             None => crashln!("{} Impossible to get your home directory", *helpers::FAIL),
@@ -137,7 +181,15 @@ impl Config {
         self
     }
 
-    pub fn fmt_address(&self) -> String { format!("{}:{}", self.daemon.web.address.clone(), self.daemon.web.port) }
+    pub fn fmt_address(&self) -> String {
+        format!(
+            "{}:{}",
+            self.daemon.web.address.clone(),
+            self.daemon.web.port
+        )
+    }
 
-    pub fn get_path(&self) -> String { self.daemon.web.path.clone().unwrap_or(string!("/")) }
+    pub fn get_path(&self) -> String {
+        self.daemon.web.path.clone().unwrap_or(string!("/"))
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -60,7 +60,7 @@ pub fn read() -> Config {
                         kind: string!("default"),
                         web: Web {
                             ui: false,
-                            api: false,
+                            api: true,
                             address: string!("0.0.0.0"),
                             path: None,
                             port: 5630,
@@ -104,13 +104,14 @@ pub fn servers() -> Servers {
             let config_path = format!("{path}/.pmc/servers.toml");
 
             if !Exists::check(&config_path).file()
-                && let Err(err) = write(&config_path, "") {
-                    crashln!(
-                        "{} Error writing servers.\n{}",
-                        *helpers::FAIL,
-                        string!(err).white()
-                    )
-                }
+                && let Err(err) = write(&config_path, "")
+            {
+                crashln!(
+                    "{} Error writing servers.\n{}",
+                    *helpers::FAIL,
+                    string!(err).white()
+                )
+            }
 
             file::read(config_path)
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -103,15 +103,14 @@ pub fn servers() -> Servers {
             let path = path.display();
             let config_path = format!("{path}/.pmc/servers.toml");
 
-            if !Exists::check(&config_path).file() {
-                if let Err(err) = write(&config_path, "") {
+            if !Exists::check(&config_path).file()
+                && let Err(err) = write(&config_path, "") {
                     crashln!(
                         "{} Error writing servers.\n{}",
                         *helpers::FAIL,
                         string!(err).white()
                     )
                 }
-            }
 
             file::read(config_path)
         }

--- a/src/daemon/api/docs.rs
+++ b/src/daemon/api/docs.rs
@@ -12,8 +12,13 @@ pub struct Docs {
 impl Docs {
     pub fn new() -> Self {
         let s_path = config::read().get_path().trim_end_matches('/').to_string();
-        Self { s_path, html: Cow::Borrowed(INDEX) }
+        Self {
+            s_path,
+            html: Cow::Borrowed(INDEX),
+        }
     }
 
-    pub fn render(&self) -> String { self.html.replace("$s_path", &self.s_path) }
+    pub fn render(&self) -> String {
+        self.html.replace("$s_path", &self.s_path)
+    }
 }

--- a/src/daemon/api/fairing.rs
+++ b/src/daemon/api/fairing.rs
@@ -1,8 +1,7 @@
 use rocket::{
-    async_trait,
+    Data, Orbit, Request, Response, Rocket, async_trait,
     fairing::{Fairing, Info, Kind},
     http::{ContentType, Header},
-    Data, Orbit, Request, Response, Rocket,
 };
 
 #[async_trait]
@@ -57,8 +56,17 @@ impl Fairing for super::AddCORS {
     async fn on_response<'r>(&self, _request: &'r Request<'_>, response: &mut Response<'r>) {
         response.set_header(Header::new("Access-Control-Allow-Origin", "*"));
         response.set_header(Header::new("Access-Control-Allow-Credentials", "true"));
-        response.set_header(Header::new("Access-Control-Allow-Methods", "POST, GET, OPTIONS"));
-        response.set_header(Header::new("Access-Control-Allow-Headers", "token, Content-Type, Accept"));
-        response.set_header(Header::new("Access-Control-Expose-Headers", "Content-Encoding, Content-Type"));
+        response.set_header(Header::new(
+            "Access-Control-Allow-Methods",
+            "POST, GET, OPTIONS",
+        ));
+        response.set_header(Header::new(
+            "Access-Control-Allow-Headers",
+            "token, Content-Type, Accept",
+        ));
+        response.set_header(Header::new(
+            "Access-Control-Expose-Headers",
+            "Content-Encoding, Content-Type",
+        ));
     }
 }

--- a/src/daemon/api/helpers.rs
+++ b/src/daemon/api/helpers.rs
@@ -4,9 +4,16 @@ use rocket::{http::Status, response::status, serde::json::Json};
 pub(crate) type NotFound = status::NotFound<Json<ErrorMessage>>;
 pub(crate) type GenericError = status::Custom<Json<ErrorMessage>>;
 
-pub(crate) fn create_status(code: Status) -> Json<ErrorMessage> { Json(ErrorMessage { code, message: code.to_string() }) }
+pub(crate) fn create_status(code: Status) -> Json<ErrorMessage> {
+    Json(ErrorMessage {
+        code,
+        message: code.to_string(),
+    })
+}
 
-pub(crate) fn generic_error(code: Status, message: String) -> GenericError { status::Custom(code, Json(ErrorMessage { code, message })) }
+pub(crate) fn generic_error(code: Status, message: String) -> GenericError {
+    status::Custom(code, Json(ErrorMessage { code, message }))
+}
 
 pub(crate) fn not_found(msg: &str) -> NotFound {
     status::NotFound(Json(ErrorMessage {

--- a/src/daemon/api/mod.rs
+++ b/src/daemon/api/mod.rs
@@ -5,37 +5,59 @@ mod routes;
 mod structs;
 
 use crate::webui::{self, assets::NamedFile};
-use helpers::{create_status, NotFound};
-use include_dir::{include_dir, Dir};
+use helpers::{NotFound, create_status};
+use include_dir::{Dir, include_dir};
 use lazy_static::lazy_static;
 use pmc::{config, process};
-use prometheus::{opts, register_counter, register_gauge, register_histogram, register_histogram_vec};
 use prometheus::{Counter, Gauge, Histogram, HistogramVec};
-use serde_json::{json, Value};
+use prometheus::{
+    opts, register_counter, register_gauge, register_histogram, register_histogram_vec,
+};
+use serde_json::{Value, json};
 use std::sync::atomic::{AtomicBool, Ordering};
 use structs::ErrorMessage;
 use tera::Context;
 
 use utoipa::{
-    openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
     Modify, OpenApi,
+    openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
 };
 
 use rocket::{
-    catch,
+    State, catch,
     http::{ContentType, Status},
     outcome::Outcome,
     request::{self, FromRequest, Request},
     serde::json::Json,
-    State,
 };
 
 lazy_static! {
-    pub static ref HTTP_COUNTER: Counter = register_counter!(opts!("http_requests_total", "Number of HTTP requests made.")).unwrap();
-    pub static ref DAEMON_START_TIME: Gauge = register_gauge!(opts!("process_start_time_seconds", "The uptime of the daemon.")).unwrap();
-    pub static ref DAEMON_MEM_USAGE: Histogram = register_histogram!("daemon_memory_usage", "The memory usage graph of the daemon.").unwrap();
-    pub static ref DAEMON_CPU_PERCENTAGE: Histogram = register_histogram!("daemon_cpu_percentage", "The cpu usage graph of the daemon.").unwrap();
-    pub static ref HTTP_REQ_HISTOGRAM: HistogramVec = register_histogram_vec!("http_request_duration_seconds", "The HTTP request latencies in seconds.", &["route"]).unwrap();
+    pub static ref HTTP_COUNTER: Counter = register_counter!(opts!(
+        "http_requests_total",
+        "Number of HTTP requests made."
+    ))
+    .unwrap();
+    pub static ref DAEMON_START_TIME: Gauge = register_gauge!(opts!(
+        "process_start_time_seconds",
+        "The uptime of the daemon."
+    ))
+    .unwrap();
+    pub static ref DAEMON_MEM_USAGE: Histogram = register_histogram!(
+        "daemon_memory_usage",
+        "The memory usage graph of the daemon."
+    )
+    .unwrap();
+    pub static ref DAEMON_CPU_PERCENTAGE: Histogram = register_histogram!(
+        "daemon_cpu_percentage",
+        "The cpu usage graph of the daemon."
+    )
+    .unwrap();
+    pub static ref HTTP_REQ_HISTOGRAM: HistogramVec = register_histogram_vec!(
+        "http_request_duration_seconds",
+        "The HTTP request latencies in seconds.",
+        &["route"]
+    )
+    .unwrap();
 }
 
 #[derive(OpenApi)]
@@ -98,24 +120,37 @@ struct TeraState {
 impl Modify for SecurityAddon {
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
         let components = openapi.components.as_mut().unwrap();
-        components.add_security_scheme("api_key", SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("token"))))
+        components.add_security_scheme(
+            "api_key",
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("token"))),
+        )
     }
 }
 
 #[catch(500)]
-fn internal_error<'m>() -> Json<ErrorMessage> { create_status(Status::InternalServerError) }
+fn internal_error<'m>() -> Json<ErrorMessage> {
+    create_status(Status::InternalServerError)
+}
 
 #[catch(400)]
-fn bad_request<'m>() -> Json<ErrorMessage> { create_status(Status::BadRequest) }
+fn bad_request<'m>() -> Json<ErrorMessage> {
+    create_status(Status::BadRequest)
+}
 
 #[catch(405)]
-fn not_allowed<'m>() -> Json<ErrorMessage> { create_status(Status::MethodNotAllowed) }
+fn not_allowed<'m>() -> Json<ErrorMessage> {
+    create_status(Status::MethodNotAllowed)
+}
 
 #[catch(404)]
-fn not_found<'m>() -> Json<ErrorMessage> { create_status(Status::NotFound) }
+fn not_found<'m>() -> Json<ErrorMessage> {
+    create_status(Status::NotFound)
+}
 
 #[catch(401)]
-fn unauthorized<'m>() -> Json<ErrorMessage> { create_status(Status::Unauthorized) }
+fn unauthorized<'m>() -> Json<ErrorMessage> {
+    create_status(Status::Unauthorized)
+}
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for EnableWebUI {
@@ -136,7 +171,9 @@ impl<'r> FromRequest<'r> for EnableWebUI {
 impl<'r> FromRequest<'r> for routes::Token {
     type Error = ();
 
-    async fn from_request(request: &'r rocket::Request<'_>) -> rocket::request::Outcome<Self, Self::Error> {
+    async fn from_request(
+        request: &'r rocket::Request<'_>,
+    ) -> rocket::request::Outcome<Self, Self::Error> {
         let config = config::read().daemon.web;
 
         match config.secure {
@@ -145,7 +182,10 @@ impl<'r> FromRequest<'r> for routes::Token {
                     return Outcome::Success(routes::Token);
                 }
 
-                let header_valid = request.headers().get_one("token").is_some_and(|header_value| header_value == val.token);
+                let header_valid = request
+                    .headers()
+                    .get_one("token")
+                    .is_some_and(|header_value| header_value == val.token);
                 let query_valid = match request.query_value::<String>("token") {
                     Some(Ok(query_token)) => query_token == val.token,
                     _ => false,
@@ -210,9 +250,21 @@ pub async fn start(webui: bool) {
     let rocket = rocket::custom(config::read().get_address())
         .attach(Logger)
         .attach(AddCORS)
-        .manage(TeraState { path: tera.1, tera: tera.0 })
+        .manage(TeraState {
+            path: tera.1,
+            tera: tera.0,
+        })
         .mount(format!("{s_path}/"), routes)
-        .register("/", rocket::catchers![internal_error, bad_request, not_allowed, not_found, unauthorized])
+        .register(
+            "/",
+            rocket::catchers![
+                internal_error,
+                bad_request,
+                not_allowed,
+                not_found,
+                unauthorized
+            ],
+        )
         .launch()
         .await;
 
@@ -221,11 +273,18 @@ pub async fn start(webui: bool) {
     }
 }
 
-async fn render(name: &str, state: &State<TeraState>, ctx: &mut Context) -> Result<String, NotFound> {
+async fn render(
+    name: &str,
+    state: &State<TeraState>,
+    ctx: &mut Context,
+) -> Result<String, NotFound> {
     ctx.insert("base_path", &state.path);
     ctx.insert("build_version", env!("CARGO_PKG_VERSION"));
 
-    state.tera.render(name, &ctx).or(Err(helpers::not_found("Page was not found")))
+    state
+        .tera
+        .render(name, &ctx)
+        .or(Err(helpers::not_found("Page was not found")))
 }
 
 #[rocket::get("/assets/<name>")]
@@ -245,13 +304,27 @@ async fn static_assets(name: String) -> Option<NamedFile> {
 }
 
 #[rocket::get("/openapi.json")]
-async fn docs_json() -> Value { json!(ApiDoc::openapi()) }
+async fn docs_json() -> Value {
+    json!(ApiDoc::openapi())
+}
 
 #[rocket::get("/docs/embed")]
-async fn embed() -> (ContentType, String) { (ContentType::HTML, docs::Docs::new().render()) }
+async fn embed() -> (ContentType, String) {
+    (ContentType::HTML, docs::Docs::new().render())
+}
 
 #[rocket::get("/docs")]
-async fn scalar(state: &State<TeraState>, _webui: EnableWebUI) -> Result<(ContentType, String), NotFound> { Ok((ContentType::HTML, render("docs", &state, &mut Context::new()).await?)) }
+async fn scalar(
+    state: &State<TeraState>,
+    _webui: EnableWebUI,
+) -> Result<(ContentType, String), NotFound> {
+    Ok((
+        ContentType::HTML,
+        render("docs", &state, &mut Context::new()).await?,
+    ))
+}
 
 #[rocket::get("/health")]
-async fn health() -> Value { json!({"healthy": true}) }
+async fn health() -> Value {
+    json!({"healthy": true})
+}

--- a/src/daemon/api/mod.rs
+++ b/src/daemon/api/mod.rs
@@ -283,7 +283,7 @@ async fn render(
 
     state
         .tera
-        .render(name, &ctx)
+        .render(name, ctx)
         .or(Err(helpers::not_found("Page was not found")))
 }
 
@@ -320,7 +320,7 @@ async fn scalar(
 ) -> Result<(ContentType, String), NotFound> {
     Ok((
         ContentType::HTML,
-        render("docs", &state, &mut Context::new()).await?,
+        render("docs", state, &mut Context::new()).await?,
     ))
 }
 

--- a/src/daemon/api/routes.rs
+++ b/src/daemon/api/routes.rs
@@ -233,7 +233,7 @@ pub async fn server_status(
             example = json!("# HELP daemon_cpu_percentage The cpu usage graph of the daemon.\n# TYPE daemon_cpu_percentage histogram\ndaemon_cpu_percentage_bucket{le=\"0.005\"} 0"),
         ),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -252,7 +252,7 @@ pub async fn prometheus_handler(_t: Token) -> String {
     responses(
         (status = 200, description = "Get daemon servers successfully", body = [String]),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -282,7 +282,7 @@ pub async fn servers_handler(_t: Token) -> Result<Json<Vec<String>>, GenericErro
         (status = 200, description = "Get list from remote daemon successfully", body = [ProcessItem]),
         (status = NOT_FOUND, description = "Remote daemon does not exist", body = ErrorMessage),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -340,7 +340,7 @@ pub async fn remote_list(name: String, _t: Token) -> Result<Json<Vec<ProcessItem
         (status = 200, description = "Get process info from remote daemon successfully", body = [ProcessItem]),
         (status = NOT_FOUND, description = "Remote daemon does not exist", body = ErrorMessage),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -403,7 +403,7 @@ pub async fn remote_info(
         (status = 200, description = "Remote process logs of {type} fetched", body = LogResponse),
         (status = NOT_FOUND, description = "Remote daemon does not exist", body = ErrorMessage),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -457,9 +457,9 @@ pub async fn remote_logs(
 }
 
 #[post("/remote/<name>/rename/<id>", format = "text", data = "<body>")]
-#[utoipa::path(post, tag = "Remote", path = "/remote/{name}/rename/{id}", 
+#[utoipa::path(post, tag = "Remote", path = "/remote/{name}/rename/{id}",
     security((), ("api_key" = [])),
-    request_body(content = String, example = json!("example_name")), 
+    request_body(content = String, example = json!("example_name")),
     params(
         ("id" = usize, Path, description = "Process id to rename", example = 0),
         ("name" = String, Path, description = "Name of remote daemon", example = "example"),
@@ -471,7 +471,7 @@ pub async fn remote_logs(
         ),
         (status = NOT_FOUND, description = "Process was not found", body = ErrorMessage),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -537,7 +537,7 @@ pub async fn remote_rename(
         (status = 200, description = "Run action on remote process successful", body = ActionResponse),
         (status = NOT_FOUND, description = "Process/action was not found", body = ErrorMessage),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -596,7 +596,7 @@ pub async fn remote_action(
     responses(
         (status = 200, description = "Dump processes successfully", body = [u8]),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -617,7 +617,7 @@ pub async fn dump_handler(_t: Token) -> Vec<u8> {
     responses(
         (status = 200, description = "Get daemon config successfully", body = ConfigBody),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -643,7 +643,7 @@ pub async fn config_handler(_t: Token) -> Json<ConfigBody> {
     responses(
         (status = 200, description = "List processes successfully", body = [ProcessItem]),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -661,7 +661,7 @@ pub async fn list_handler(_t: Token) -> Json<Vec<ProcessItem>> {
 }
 
 #[get("/process/<id>/logs/<kind>")]
-#[utoipa::path(get, tag = "Process", path = "/process/{id}/logs/{kind}", 
+#[utoipa::path(get, tag = "Process", path = "/process/{id}/logs/{kind}",
     security((), ("api_key" = [])),
     params(
         ("id" = usize, Path, description = "Process id to get logs for", example = 0),
@@ -671,7 +671,7 @@ pub async fn list_handler(_t: Token) -> Json<Vec<ProcessItem>> {
         (status = 200, description = "Process logs of {type} fetched", body = LogResponse),
         (status = NOT_FOUND, description = "Process was not found", body = ErrorMessage),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -711,7 +711,7 @@ pub async fn logs_handler(
 }
 
 #[get("/process/<id>/logs/<kind>/raw")]
-#[utoipa::path(get, tag = "Process", path = "/process/{id}/logs/{kind}/raw", 
+#[utoipa::path(get, tag = "Process", path = "/process/{id}/logs/{kind}/raw",
     security((), ("api_key" = [])),
     params(
         ("id" = usize, Path, description = "Process id to get logs for", example = 0),
@@ -724,7 +724,7 @@ pub async fn logs_handler(
         ),
         (status = NOT_FOUND, description = "Process was not found", body = ErrorMessage),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -848,7 +848,7 @@ pub async fn logs_ws(
         (status = 200, description = "Current process info retrieved", body = ItemSingle),
         (status = NOT_FOUND, description = "Process was not found", body = ErrorMessage),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -870,7 +870,7 @@ pub async fn info_handler(id: usize, _t: Token) -> Result<Json<ItemSingle>, NotF
 }
 
 #[post("/process/create", format = "json", data = "<body>")]
-#[utoipa::path(post, tag = "Process", path = "/process/create", request_body(content = CreateBody), 
+#[utoipa::path(post, tag = "Process", path = "/process/create", request_body(content = CreateBody),
     security((), ("api_key" = [])),
     responses(
         (
@@ -879,7 +879,7 @@ pub async fn info_handler(id: usize, _t: Token) -> Result<Json<ItemSingle>, NotF
         ),
         (status = INTERNAL_SERVER_ERROR, description = "Failed to create process", body = ErrorMessage),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -906,9 +906,9 @@ pub async fn create_handler(body: Json<CreateBody>, _t: Token) -> Result<Json<Ac
 }
 
 #[post("/process/<id>/rename", format = "text", data = "<body>")]
-#[utoipa::path(post, tag = "Process", path = "/process/{id}/rename", 
+#[utoipa::path(post, tag = "Process", path = "/process/{id}/rename",
     security((), ("api_key" = [])),
-    request_body(content = String, example = json!("example_name")), 
+    request_body(content = String, example = json!("example_name")),
     params(("id" = usize, Path, description = "Process id to rename", example = 0)),
     responses(
         (
@@ -917,7 +917,7 @@ pub async fn create_handler(body: Json<CreateBody>, _t: Token) -> Result<Json<Ac
         ),
         (status = NOT_FOUND, description = "Process was not found", body = ErrorMessage),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -958,7 +958,7 @@ pub async fn rename_handler(
         ),
         (status = NOT_FOUND, description = "Process was not found", body = ErrorMessage),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -987,7 +987,7 @@ pub async fn env_handler(id: usize, _t: Token) -> Result<EnvList, NotFound> {
         (status = 200, description = "Run action on process successful", body = ActionResponse),
         (status = NOT_FOUND, description = "Process/action was not found", body = ErrorMessage),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -1056,12 +1056,13 @@ pub async fn get_metrics() -> MetricsRoot {
     HTTP_COUNTER.inc();
     if pid::exists()
         && let Ok(process_id) = pid::read()
-            && let Ok(process) = Process::new(process_id.get()) {
-                pid = Some(process_id);
-                uptime = Some(pid::uptime().unwrap());
-                memory_usage = Some(process.memory_info().unwrap().rss());
-                cpu_percent = Some(get_process_cpu_usage_percentage(process_id.get::<i64>()));
-            }
+        && let Ok(process) = Process::new(process_id.get())
+    {
+        pid = Some(process_id);
+        uptime = Some(pid::uptime().unwrap());
+        memory_usage = Some(process.memory_info().unwrap().rss());
+        cpu_percent = Some(get_process_cpu_usage_percentage(process_id.get::<i64>()));
+    }
 
     let memory_usage_fmt = match memory_usage {
         Some(usage) => helpers::format_memory(usage),
@@ -1114,7 +1115,7 @@ pub async fn get_metrics() -> MetricsRoot {
     responses(
         (status = 200, description = "Get daemon metrics", body = MetricsRoot),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )
@@ -1129,7 +1130,7 @@ pub async fn metrics_handler(_t: Token) -> Json<MetricsRoot> {
     responses(
         (status = 200, description = "Get remote metrics", body = MetricsRoot),
         (
-            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage, 
+            status = UNAUTHORIZED, description = "Authentication failed or not provided", body = ErrorMessage,
             example = json!({"code": 401, "message": "Unauthorized"})
         )
     )

--- a/src/daemon/api/structs.rs
+++ b/src/daemon/api/structs.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use utoipa::{
-    openapi::{KnownFormat, Object, ObjectBuilder, SchemaFormat, SchemaType},
     ToSchema,
+    openapi::{KnownFormat, Object, ObjectBuilder, SchemaFormat, SchemaType},
 };
 
 #[derive(Serialize, Deserialize, ToSchema)]

--- a/src/daemon/fork.rs
+++ b/src/daemon/fork.rs
@@ -39,10 +39,10 @@ pub fn close_fd() -> Result<i32, i32> {
         res |= unsafe { libc::close(i) } == -1;
     }
 
-    return match res {
+    match res {
         true => Err(-1),
         false => Ok(1),
-    };
+    }
 }
 
 pub fn daemon(nochdir: bool, noclose: bool) -> Result<Fork, i32> {

--- a/src/daemon/log.rs
+++ b/src/daemon/log.rs
@@ -40,6 +40,6 @@ macro_rules! log {
     ($msg:expr, $($key:expr => $value:expr),* $(,)?) => {{
         let mut args = std::collections::HashMap::new();
         $(args.insert($key.to_string(), format!("{}", $value));)*
-        crate::daemon::log::Logger::new().unwrap().write($msg, args)
+        $crate::daemon::log::Logger::new().unwrap().write($msg, args)
     }}
 }

--- a/src/daemon/log.rs
+++ b/src/daemon/log.rs
@@ -10,16 +10,28 @@ pub struct Logger {
 
 impl Logger {
     pub fn new() -> io::Result<Self> {
-        let file = OpenOptions::new().create(true).append(true).open(global!("pmc.daemon.log"))?;
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(global!("pmc.daemon.log"))?;
         Ok(Logger { file })
     }
 
     pub fn write(&mut self, message: &str, args: HashMap<String, String>) {
-        let args = args.iter().map(|(key, value)| format!("{}={}", key, value)).collect::<Vec<String>>().join(", ");
+        let args = args
+            .iter()
+            .map(|(key, value)| format!("{}={}", key, value))
+            .collect::<Vec<String>>()
+            .join(", ");
         let msg = format!("{message} ({args})");
 
         log::info!("{msg}");
-        writeln!(&mut self.file, "[{}] {msg}", Local::now().format("%Y-%m-%d %H:%M:%S%.3f")).unwrap()
+        writeln!(
+            &mut self.file,
+            "[{}] {msg}",
+            Local::now().format("%Y-%m-%d %H:%M:%S%.3f")
+        )
+        .unwrap()
     }
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -127,12 +127,13 @@ pub fn health(format: &String) {
 
     if pid::exists()
         && let Ok(process_id) = pid::read()
-            && let Ok(process) = Process::new(process_id.get::<u32>()) {
-                pid = Some(process.pid() as i32);
-                uptime = Some(pid::uptime().unwrap());
-                memory_usage = process.memory_info().ok().map(MemoryInfo::from);
-                cpu_percent = Some(get_process_cpu_usage_percentage(process_id.get::<i64>()));
-            }
+        && let Ok(process) = Process::new(process_id.get::<u32>())
+    {
+        pid = Some(process.pid() as i32);
+        uptime = Some(pid::uptime().unwrap());
+        memory_usage = process.memory_info().ok().map(MemoryInfo::from);
+        cpu_percent = Some(get_process_cpu_usage_percentage(process_id.get::<i64>()));
+    }
 
     let cpu_percent = match cpu_percent {
         Some(percent) => format!("{:.2}%", percent),
@@ -184,15 +185,22 @@ pub fn health(format: &String) {
             "default" => {
                 println!(
                     "{}\n{table}\n",
-                    "PMC daemon information".to_string().on_bright_white().black()
+                    "PMC daemon information"
+                        .to_string()
+                        .on_bright_white()
+                        .black()
                 );
                 println!(
                     " {}",
-                    "Use `pmc daemon restart` to restart the daemon".to_string().white()
+                    "Use `pmc daemon restart` to restart the daemon"
+                        .to_string()
+                        .white()
                 );
                 println!(
                     " {}",
-                    "Use `pmc daemon reset` to clean process id values".to_string().white()
+                    "Use `pmc daemon reset` to clean process id values"
+                        .to_string()
+                        .white()
                 );
             }
             _ => {}
@@ -234,6 +242,8 @@ pub fn start(verbose: bool) {
             config::read().fmt_address(),
             ENABLE_WEBUI.load(Ordering::Acquire)
         );
+    } else {
+        log!("[api] server disabled", "address" => config::read().fmt_address());
     }
 
     if pid::exists() {
@@ -264,12 +274,11 @@ pub fn start(verbose: bool) {
         }
 
         loop {
-            if api_enabled
-                && let Ok(process) = Process::new(process::id()) {
-                    DAEMON_CPU_PERCENTAGE
-                        .observe(get_process_cpu_usage_percentage(process.pid() as i64));
-                    DAEMON_MEM_USAGE.observe(process.memory_info().ok().unwrap().rss() as f64);
-                }
+            if api_enabled && let Ok(process) = Process::new(process::id()) {
+                DAEMON_CPU_PERCENTAGE
+                    .observe(get_process_cpu_usage_percentage(process.pid() as i64));
+                DAEMON_MEM_USAGE.observe(process.memory_info().ok().unwrap().rss() as f64);
+            }
 
             then!(!Runner::new().is_empty(), restart_process());
             sleep(Duration::from_millis(config.interval));

--- a/src/daemon/pid.rs
+++ b/src/daemon/pid.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use core::fmt;
 use global_placeholders::global;
@@ -21,11 +21,17 @@ impl Pid {
 }
 
 impl fmt::Display for Pid {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.0) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
-pub fn exists() -> bool { fs::metadata(global!("pmc.pid")).is_ok() }
-pub fn running(pid: i32) -> bool { unsafe { libc::kill(pid, 0) == 0 } }
+pub fn exists() -> bool {
+    fs::metadata(global!("pmc.pid")).is_ok()
+}
+pub fn running(pid: i32) -> bool {
+    unsafe { libc::kill(pid, 0) == 0 }
+}
 
 pub fn uptime() -> io::Result<DateTime<Utc>> {
     let metadata = fs::metadata(global!("pmc.pid"))?;
@@ -70,7 +76,13 @@ pub fn name(new_name: &str) {
 
     unsafe {
         libc::setpgid(pid, 0);
-        libc::prctl(libc::PR_SET_NAME, name_cstr.as_ptr() as libc::c_ulong, 0, 0, 0);
+        libc::prctl(
+            libc::PR_SET_NAME,
+            name_cstr.as_ptr() as libc::c_ulong,
+            0,
+            0,
+            0,
+        );
     }
 }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -52,7 +52,7 @@ pub fn logs_internal(
         0
     };
 
-    for (_, line) in lines.iter().skip(start_index).enumerate() {
+    for line in lines.iter().skip(start_index) {
         println!(
             "{} {}",
             format!("{}|{} |", id, item_name).color(color),
@@ -127,7 +127,7 @@ pub fn read<T: serde::de::DeserializeOwned>(path: String) -> T {
 }
 
 pub fn from_object<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
-    match ron::de::from_bytes(&bytes) {
+    match ron::de::from_bytes(bytes) {
         Ok(parsed) => parsed,
         Err(err) => crashln!(
             "{} Cannot parse file.\n{}",

--- a/src/file.rs
+++ b/src/file.rs
@@ -21,7 +21,10 @@ pub fn logs(item: &Process, lines_to_tail: usize, kind: &str) {
     if !Exists::check(&log_file).empty() {
         let file = File::open(&log_file).unwrap();
         let reader = BufReader::new(file);
-        let lines = reader.lines().map(|line| line.unwrap_or_else(|err| format!("error reading line: {err}"))).collect();
+        let lines = reader
+            .lines()
+            .map(|line| line.unwrap_or_else(|err| format!("error reading line: {err}")))
+            .collect();
 
         logs_internal(lines, lines_to_tail, &log_file, item.id, kind, &item.name)
     } else {
@@ -29,21 +32,42 @@ pub fn logs(item: &Process, lines_to_tail: usize, kind: &str) {
     }
 }
 
-pub fn logs_internal(lines: Vec<String>, lines_to_tail: usize, log_file: &str, id: usize, log_type: &str, item_name: &str) {
-    println!("{}", format!("\n{log_file} last {lines_to_tail} lines:").bright_black());
+pub fn logs_internal(
+    lines: Vec<String>,
+    lines_to_tail: usize,
+    log_file: &str,
+    id: usize,
+    log_type: &str,
+    item_name: &str,
+) {
+    println!(
+        "{}",
+        format!("\n{log_file} last {lines_to_tail} lines:").bright_black()
+    );
 
     let color = ternary!(log_type == "out", "green", "red");
-    let start_index = if lines.len() > lines_to_tail { lines.len() - lines_to_tail } else { 0 };
+    let start_index = if lines.len() > lines_to_tail {
+        lines.len() - lines_to_tail
+    } else {
+        0
+    };
 
     for (_, line) in lines.iter().skip(start_index).enumerate() {
-        println!("{} {}", format!("{}|{} |", id, item_name).color(color), line);
+        println!(
+            "{} {}",
+            format!("{}|{} |", id, item_name).color(color),
+            line
+        );
     }
 }
 
 pub fn cwd() -> PathBuf {
     match env::current_dir() {
         Ok(path) => path,
-        Err(_) => crashln!("{} Unable to find current working directory", *helpers::FAIL),
+        Err(_) => crashln!(
+            "{} Unable to find current working directory",
+            *helpers::FAIL
+        ),
     }
 }
 
@@ -59,23 +83,41 @@ pub struct Exists<'p> {
 }
 
 impl<'p> Exists<'p> {
-    pub fn check(path: &'p str) -> Self { Self { path } }
-    pub fn folder(&self) -> bool { Path::new(self.path).is_dir() }
-    pub fn file(&self) -> bool { Path::new(self.path).exists() }
-    pub fn empty(&self) -> bool { fs::metadata(Path::new(self.path)).map(|m| m.len() == 0).unwrap_or(true) }
+    pub fn check(path: &'p str) -> Self {
+        Self { path }
+    }
+    pub fn folder(&self) -> bool {
+        Path::new(self.path).is_dir()
+    }
+    pub fn file(&self) -> bool {
+        Path::new(self.path).exists()
+    }
+    pub fn empty(&self) -> bool {
+        fs::metadata(Path::new(self.path))
+            .map(|m| m.len() == 0)
+            .unwrap_or(true)
+    }
 }
 
 pub fn raw(path: String) -> Vec<u8> {
     match fs::read(&path) {
         Ok(contents) => contents,
-        Err(err) => crashln!("{} Cannot find dumpfile.\n{}", *helpers::FAIL, string!(err).white()),
+        Err(err) => crashln!(
+            "{} Cannot find dumpfile.\n{}",
+            *helpers::FAIL,
+            string!(err).white()
+        ),
     }
 }
 
 pub fn read<T: serde::de::DeserializeOwned>(path: String) -> T {
     let contents = match fs::read_to_string(&path) {
         Ok(contents) => contents,
-        Err(err) => crashln!("{} Cannot find dumpfile.\n{}", *helpers::FAIL, string!(err).white()),
+        Err(err) => crashln!(
+            "{} Cannot find dumpfile.\n{}",
+            *helpers::FAIL,
+            string!(err).white()
+        ),
     };
 
     match toml::from_str(&contents).map_err(|err| string!(err)) {
@@ -87,7 +129,11 @@ pub fn read<T: serde::de::DeserializeOwned>(path: String) -> T {
 pub fn from_object<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
     match ron::de::from_bytes(&bytes) {
         Ok(parsed) => parsed,
-        Err(err) => crashln!("{} Cannot parse file.\n{}", *helpers::FAIL, string!(err).white()),
+        Err(err) => crashln!(
+            "{} Cannot parse file.\n{}",
+            *helpers::FAIL,
+            string!(err).white()
+        ),
     }
 }
 
@@ -102,10 +148,19 @@ pub fn read_object<T: serde::de::DeserializeOwned>(path: String) -> T {
                 retry_count += 1;
                 if retry_count >= max_retries {
                     log!("file::read] Cannot find file: {err}");
-                    println!("{} Cannot find file.\n{}", *helpers::FAIL, string!(err).white());
+                    println!(
+                        "{} Cannot find file.\n{}",
+                        *helpers::FAIL,
+                        string!(err).white()
+                    );
                 } else {
-                    log!("file::read] Error reading file. Retrying... (Attempt {retry_count}/{max_retries})");
-                    println!("{} Error reading file. Retrying... (Attempt {retry_count}/{max_retries})", *helpers::FAIL);
+                    log!(
+                        "file::read] Error reading file. Retrying... (Attempt {retry_count}/{max_retries})"
+                    );
+                    println!(
+                        "{} Error reading file. Retrying... (Attempt {retry_count}/{max_retries})",
+                        *helpers::FAIL
+                    );
                 }
             }
         }
@@ -121,10 +176,19 @@ pub fn read_object<T: serde::de::DeserializeOwned>(path: String) -> T {
                 retry_count += 1;
                 if retry_count >= max_retries {
                     log!("[file::parse] Cannot parse file: {err}");
-                    println!("{} Cannot parse file.\n{}", *helpers::FAIL, string!(err).white());
+                    println!(
+                        "{} Cannot parse file.\n{}",
+                        *helpers::FAIL,
+                        string!(err).white()
+                    );
                 } else {
-                    log!("[file::parse] Error parsing file. Retrying... (Attempt {retry_count}/{max_retries})");
-                    println!("{} Error parsing file. Retrying... (Attempt {retry_count}/{max_retries})", *helpers::FAIL);
+                    log!(
+                        "[file::parse] Error parsing file. Retrying... (Attempt {retry_count}/{max_retries})"
+                    );
+                    println!(
+                        "{} Error parsing file. Retrying... (Attempt {retry_count}/{max_retries})",
+                        *helpers::FAIL
+                    );
                 }
             }
         }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -22,11 +22,15 @@ impl serde::Serialize for ColoredString {
 }
 
 impl From<colored::ColoredString> for ColoredString {
-    fn from(cs: colored::ColoredString) -> Self { ColoredString(cs) }
+    fn from(cs: colored::ColoredString) -> Self {
+        ColoredString(cs)
+    }
 }
 
 impl fmt::Display for ColoredString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.0) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 pub fn format_duration(datetime: DateTime<Utc>) -> String {
@@ -53,7 +57,9 @@ pub fn format_memory(bytes: u64) -> String {
     }
 
     let mut buffer = ryu::Buffer::new();
-    let result = buffer.format((UNIT.powf(base - base.floor()) * 10.0).round() / 10.0).trim_end_matches(".0");
+    let result = buffer
+        .format((UNIT.powf(base - base.floor()) * 10.0).round() / 10.0)
+        .trim_end_matches(".0");
 
     [result, SUFFIX[base.floor() as usize]].join("")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,4 +24,6 @@ pub mod process;
 // }
 
 // Re-export Rust implementations outside of cxx bridge
-pub use process::{get_process_cpu_usage_percentage, process_stop, process_find_children, process_run};
+pub use process::{
+    get_process_cpu_usage_percentage, process_find_children, process_run, process_stop,
+};

--- a/src/log.rs
+++ b/src/log.rs
@@ -9,13 +9,22 @@ pub struct Logger {
 
 impl Logger {
     pub fn new() -> io::Result<Self> {
-        let file = OpenOptions::new().create(true).append(true).open(global!("pmc.log"))?;
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(global!("pmc.log"))?;
         Ok(Logger { file })
     }
 
     pub fn write(&mut self, message: &str) {
         log::info!("{message}");
-        writeln!(&mut self.file, "[{}] {}", Local::now().format("%Y-%m-%d %H:%M:%S%.3f"), message).unwrap()
+        writeln!(
+            &mut self.file,
+            "[{}] {}",
+            Local::now().format("%Y-%m-%d %H:%M:%S%.3f"),
+            message
+        )
+        .unwrap()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,17 +6,19 @@ mod webui;
 use clap::{Parser, Subcommand};
 use clap_verbosity_flag::{LogLevel, Verbosity};
 use macros_rs::{str, string, then};
-use update_informer::{registry, Check};
+use update_informer::{Check, registry};
 
 use crate::{
-    cli::{internal::Internal, Args, Item},
+    cli::{Args, Item, internal::Internal},
     globals::defaults,
 };
 
 #[derive(Copy, Clone, Debug, Default)]
 struct NoneLevel;
 impl LogLevel for NoneLevel {
-    fn default() -> Option<log::Level> { None }
+    fn default() -> Option<log::Level> {
+        None
+    }
 }
 
 #[derive(Parser)]
@@ -220,7 +222,10 @@ fn main() {
     let informer = update_informer::new(registry::Crates, "pmc", env!("CARGO_PKG_VERSION"));
 
     if let Some(version) = informer.check_version().ok().flatten() {
-        println!("{} New version is available: {version}", *pmc::helpers::WARN);
+        println!(
+            "{} New version is available: {version}",
+            *pmc::helpers::WARN
+        );
     }
 
     globals::init();
@@ -229,15 +234,29 @@ fn main() {
     match &cli.command {
         Commands::Import { path } => cli::import::read_hcl(path),
         Commands::Export { item, path } => cli::import::export_hcl(item, path),
-        Commands::Start { name, args, watch, server, reset_env } => cli::start(name, args, watch, reset_env, &defaults(server)),
+        Commands::Start {
+            name,
+            args,
+            watch,
+            server,
+            reset_env,
+        } => cli::start(name, args, watch, reset_env, &defaults(server)),
         Commands::Stop { item, server } => cli::stop(item, &defaults(server)),
         Commands::Remove { item, server } => cli::remove(item, &defaults(server)),
         Commands::Restore { server } => Internal::restore(&defaults(server)),
         Commands::Save { server } => Internal::save(&defaults(server)),
         Commands::Env { item, server } => cli::env(item, &defaults(server)),
-        Commands::Details { item, format, server } => cli::info(item, format, &defaults(server)),
+        Commands::Details {
+            item,
+            format,
+            server,
+        } => cli::info(item, format, &defaults(server)),
         Commands::List { format, server } => Internal::list(format, &defaults(server)),
-        Commands::Logs { item, lines, server } => cli::logs(item, lines, &defaults(server)),
+        Commands::Logs {
+            item,
+            lines,
+            server,
+        } => cli::logs(item, lines, &defaults(server)),
         Commands::Flush { item, server } => cli::flush(item, &defaults(server)),
 
         Commands::Daemon { command } => match command {
@@ -261,6 +280,9 @@ fn main() {
         && !matches!(&cli.command, Commands::Env { .. })
         && !matches!(&cli.command, Commands::Export { .. })
     {
-        then!(!daemon::pid::exists(), daemon::restart(&false, &false, false));
+        then!(
+            !daemon::pid::exists(),
+            daemon::restart(&false, &false, false)
+        );
     }
 }

--- a/src/process/dump.rs
+++ b/src/process/dump.rs
@@ -1,7 +1,7 @@
 use crate::{
     file::{self, Exists},
     helpers, log,
-    process::{id::Id, Runner},
+    process::{Runner, id::Id},
 };
 
 use colored::Colorize;
@@ -16,10 +16,16 @@ pub fn from(address: &str, token: Option<&str>) -> Result<Runner, anyhow::Error>
     let mut headers = HeaderMap::new();
 
     if let Some(token) = token {
-        headers.insert("token", HeaderValue::from_static(Box::leak(Box::from(token))));
+        headers.insert(
+            "token",
+            HeaderValue::from_static(Box::leak(Box::from(token))),
+        );
     }
 
-    let response = client.get(fmtstr!("{address}/daemon/dump")).headers(headers).send()?;
+    let response = client
+        .get(fmtstr!("{address}/daemon/dump"))
+        .headers(headers)
+        .send()?;
     let bytes = response.bytes()?;
 
     Ok(file::from_object(&bytes))
@@ -58,10 +64,18 @@ pub fn raw() -> Vec<u8> {
 pub fn write(dump: &Runner) {
     let encoded = match ron::ser::to_string(&dump) {
         Ok(contents) => contents,
-        Err(err) => crashln!("{} Cannot encode dump.\n{}", *helpers::FAIL, string!(err).white()),
+        Err(err) => crashln!(
+            "{} Cannot encode dump.\n{}",
+            *helpers::FAIL,
+            string!(err).white()
+        ),
     };
 
     if let Err(err) = fs::write(global!("pmc.dump"), encoded) {
-        crashln!("{} Error writing dumpfile.\n{}", *helpers::FAIL, string!(err).white())
+        crashln!(
+            "{} Error writing dumpfile.\n{}",
+            *helpers::FAIL,
+            string!(err).white()
+        )
     }
 }

--- a/src/process/hash.rs
+++ b/src/process/hash.rs
@@ -1,10 +1,14 @@
 use macros_rs::crashln;
-use merkle_hash::{bytes_to_hex, Algorithm, MerkleTree};
+use merkle_hash::{Algorithm, MerkleTree, bytes_to_hex};
 use std::path::PathBuf;
 
 pub fn create(path: PathBuf) -> String {
     log::info!("creating hash for {:?}", path);
-    let tree = match MerkleTree::builder(&path.to_str().unwrap()).algorithm(Algorithm::Blake3).hash_names(false).build() {
+    let tree = match MerkleTree::builder(&path.to_str().unwrap())
+        .algorithm(Algorithm::Blake3)
+        .hash_names(false)
+        .build()
+    {
         Ok(v) => v,
         // fix issue on post /daemon/create
         Err(e) => crashln!("Invalid UTF-8 sequence: {}", e),

--- a/src/process/hash.rs
+++ b/src/process/hash.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 pub fn create(path: PathBuf) -> String {
     log::info!("creating hash for {:?}", path);
-    let tree = match MerkleTree::builder(&path.to_str().unwrap())
+    let tree = match MerkleTree::builder(path.to_str().unwrap())
         .algorithm(Algorithm::Blake3)
         .hash_names(false)
         .build()

--- a/src/process/http.rs
+++ b/src/process/http.rs
@@ -1,7 +1,7 @@
 use crate::process::Remote;
 use macros_rs::{fmtstr, string};
-use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Client;
+use reqwest::header::{HeaderMap, HeaderValue};
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -51,66 +51,158 @@ pub async fn client(token: &Option<String>) -> (Client, HeaderMap) {
     return (client, headers);
 }
 
-pub fn info(Remote { address, token, .. }: &Remote, id: usize) -> Result<sync::Response, anyhow::Error> {
+pub fn info(
+    Remote { address, token, .. }: &Remote,
+    id: usize,
+) -> Result<sync::Response, anyhow::Error> {
     let (client, headers) = sync::client(token);
-    Ok(client.get(fmtstr!("{address}/process/{id}/info")).headers(headers).send()?)
+    Ok(client
+        .get(fmtstr!("{address}/process/{id}/info"))
+        .headers(headers)
+        .send()?)
 }
 
-pub fn logs(Remote { address, token, .. }: &Remote, id: usize, kind: &str) -> Result<LogResponse, anyhow::Error> {
+pub fn logs(
+    Remote { address, token, .. }: &Remote,
+    id: usize,
+    kind: &str,
+) -> Result<LogResponse, anyhow::Error> {
     let (client, headers) = sync::client(token);
-    let response = client.get(fmtstr!("{address}/process/{id}/logs/{kind}/raw")).headers(headers).send()?;
+    let response = client
+        .get(fmtstr!("{address}/process/{id}/logs/{kind}/raw"))
+        .headers(headers)
+        .send()?;
     let log = response.text()?;
 
     Ok(LogResponse {
-        lines: log.lines().skip(1).map(|line| line.to_string()).collect::<Vec<String>>(),
-        path: Box::leak(Box::from(log.lines().next().unwrap_or("").split_whitespace().last().unwrap_or(""))),
+        lines: log
+            .lines()
+            .skip(1)
+            .map(|line| line.to_string())
+            .collect::<Vec<String>>(),
+        path: Box::leak(Box::from(
+            log.lines()
+                .next()
+                .unwrap_or("")
+                .split_whitespace()
+                .last()
+                .unwrap_or(""),
+        )),
     })
 }
 
-pub fn create(Remote { address, token, .. }: &Remote, name: &String, script: &String, path: PathBuf, watch: &Option<String>) -> Result<sync::Response, anyhow::Error> {
+pub fn create(
+    Remote { address, token, .. }: &Remote,
+    name: &String,
+    script: &String,
+    path: PathBuf,
+    watch: &Option<String>,
+) -> Result<sync::Response, anyhow::Error> {
     let (client, headers) = sync::client(token);
-    let content = CreateBody { name, script, path, watch };
+    let content = CreateBody {
+        name,
+        script,
+        path,
+        watch,
+    };
 
-    Ok(client.post(fmtstr!("{address}/process/create")).json(&content).headers(headers).send()?)
+    Ok(client
+        .post(fmtstr!("{address}/process/create"))
+        .json(&content)
+        .headers(headers)
+        .send()?)
 }
 
-pub fn restart(Remote { address, token, .. }: &Remote, id: usize) -> Result<sync::Response, anyhow::Error> {
+pub fn restart(
+    Remote { address, token, .. }: &Remote,
+    id: usize,
+) -> Result<sync::Response, anyhow::Error> {
     let (client, headers) = sync::client(token);
-    let content = ActionBody { method: string!("restart") };
+    let content = ActionBody {
+        method: string!("restart"),
+    };
 
-    Ok(client.post(fmtstr!("{address}/process/{id}/action")).json(&content).headers(headers).send()?)
+    Ok(client
+        .post(fmtstr!("{address}/process/{id}/action"))
+        .json(&content)
+        .headers(headers)
+        .send()?)
 }
 
-pub fn rename(Remote { address, token, .. }: &Remote, id: usize, name: String) -> Result<sync::Response, anyhow::Error> {
+pub fn rename(
+    Remote { address, token, .. }: &Remote,
+    id: usize,
+    name: String,
+) -> Result<sync::Response, anyhow::Error> {
     let (client, headers) = sync::client(token);
-    Ok(client.post(fmtstr!("{address}/process/{id}/rename")).body(name).headers(headers).send()?)
+    Ok(client
+        .post(fmtstr!("{address}/process/{id}/rename"))
+        .body(name)
+        .headers(headers)
+        .send()?)
 }
 
 // merge into one function
-pub fn stop(Remote { address, token, .. }: &Remote, id: usize) -> Result<sync::Response, anyhow::Error> {
+pub fn stop(
+    Remote { address, token, .. }: &Remote,
+    id: usize,
+) -> Result<sync::Response, anyhow::Error> {
     let (client, headers) = sync::client(token);
-    let content = ActionBody { method: string!("stop") };
+    let content = ActionBody {
+        method: string!("stop"),
+    };
 
-    Ok(client.post(fmtstr!("{address}/process/{id}/action")).json(&content).headers(headers).send()?)
+    Ok(client
+        .post(fmtstr!("{address}/process/{id}/action"))
+        .json(&content)
+        .headers(headers)
+        .send()?)
 }
 
-pub fn remove(Remote { address, token, .. }: &Remote, id: usize) -> Result<sync::Response, anyhow::Error> {
+pub fn remove(
+    Remote { address, token, .. }: &Remote,
+    id: usize,
+) -> Result<sync::Response, anyhow::Error> {
     let (client, headers) = sync::client(token);
-    let content = ActionBody { method: string!("remove") };
+    let content = ActionBody {
+        method: string!("remove"),
+    };
 
-    Ok(client.post(fmtstr!("{address}/process/{id}/action")).json(&content).headers(headers).send()?)
+    Ok(client
+        .post(fmtstr!("{address}/process/{id}/action"))
+        .json(&content)
+        .headers(headers)
+        .send()?)
 }
 
-pub fn flush(Remote { address, token, .. }: &Remote, id: usize) -> Result<sync::Response, anyhow::Error> {
+pub fn flush(
+    Remote { address, token, .. }: &Remote,
+    id: usize,
+) -> Result<sync::Response, anyhow::Error> {
     let (client, headers) = sync::client(token);
-    let content = ActionBody { method: string!("flush") };
+    let content = ActionBody {
+        method: string!("flush"),
+    };
 
-    Ok(client.post(fmtstr!("{address}/process/{id}/action")).json(&content).headers(headers).send()?)
+    Ok(client
+        .post(fmtstr!("{address}/process/{id}/action"))
+        .json(&content)
+        .headers(headers)
+        .send()?)
 }
 
-pub fn clear_env(Remote { address, token, .. }: &Remote, id: usize) -> Result<sync::Response, anyhow::Error> {
+pub fn clear_env(
+    Remote { address, token, .. }: &Remote,
+    id: usize,
+) -> Result<sync::Response, anyhow::Error> {
     let (client, headers) = sync::client(token);
-    let content = ActionBody { method: string!("clear_env") };
+    let content = ActionBody {
+        method: string!("clear_env"),
+    };
 
-    Ok(client.post(fmtstr!("{address}/process/{id}/action")).json(&content).headers(headers).send()?)
+    Ok(client
+        .post(fmtstr!("{address}/process/{id}/action"))
+        .json(&content)
+        .headers(headers)
+        .send()?)
 }

--- a/src/process/http.rs
+++ b/src/process/http.rs
@@ -33,10 +33,10 @@ pub mod sync {
         let mut headers = HeaderMap::new();
 
         if let Some(token) = token {
-            headers.insert("token", HeaderValue::from_str(&token).unwrap());
+            headers.insert("token", HeaderValue::from_str(token).unwrap());
         }
 
-        return (client, headers);
+        (client, headers)
     }
 }
 
@@ -45,10 +45,10 @@ pub async fn client(token: &Option<String>) -> (Client, HeaderMap) {
     let mut headers = HeaderMap::new();
 
     if let Some(token) = token {
-        headers.insert("token", HeaderValue::from_str(&token).unwrap());
+        headers.insert("token", HeaderValue::from_str(token).unwrap());
     }
 
-    return (client, headers);
+    (client, headers)
 }
 
 pub fn info(

--- a/src/process/id.rs
+++ b/src/process/id.rs
@@ -9,8 +9,14 @@ pub struct Id {
 }
 
 impl Id {
-    pub fn new(start: usize) -> Self { Id { counter: AtomicUsize::new(start) } }
-    pub fn next(&self) -> usize { self.counter.fetch_add(1, Ordering::SeqCst) }
+    pub fn new(start: usize) -> Self {
+        Id {
+            counter: AtomicUsize::new(start),
+        }
+    }
+    pub fn next(&self) -> usize {
+        self.counter.fetch_add(1, Ordering::SeqCst)
+    }
 }
 
 impl Clone for Id {
@@ -43,5 +49,7 @@ impl From<&str> for Id {
 }
 
 impl fmt::Display for Id {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.counter.load(Ordering::SeqCst)) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.counter.load(Ordering::SeqCst))
+    }
 }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -232,6 +232,12 @@ fn kill_children(children: Vec<i64>) {
     }
 }
 
+impl Default for Runner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Runner {
     pub fn new() -> Self {
         dump::read()
@@ -336,7 +342,7 @@ impl Runner {
             );
         }
 
-        return self;
+        self
     }
 
     pub fn restart(&mut self, id: usize, dead: bool) -> &mut Self {
@@ -399,7 +405,7 @@ impl Runner {
             }
         }
 
-        return self;
+        self
     }
 
     pub fn remove(&mut self, id: usize) {
@@ -438,7 +444,7 @@ impl Runner {
     }
 
     pub fn save(&self) {
-        then!(self.remote.is_none(), dump::write(&self))
+        then!(self.remote.is_none(), dump::write(self))
     }
 
     pub fn count(&mut self) -> usize {
@@ -464,11 +470,11 @@ impl Runner {
     }
 
     pub fn size(&self) -> Option<&usize> {
-        self.list.iter().map(|(k, _)| k).max()
+        self.list.keys().max()
     }
 
-    pub fn list<'l>(&'l mut self) -> impl Iterator<Item = (&'l usize, &'l mut Process)> {
-        self.list.iter_mut().map(|(k, v)| (k, v))
+    pub fn list(&mut self) -> impl Iterator<Item = (&usize, &mut Process)> {
+        self.list.iter_mut()
     }
 
     pub fn process(&mut self, id: usize) -> &mut Process {
@@ -493,12 +499,12 @@ impl Runner {
 
     pub fn set_crashed(&mut self, id: usize) -> &mut Self {
         self.process(id).crash.crashed = true;
-        return self;
+        self
     }
 
     pub fn set_env(&mut self, id: usize, env: Env) -> &mut Self {
         self.process(id).env.extend(env);
-        return self;
+        self
     }
 
     pub fn clear_env(&mut self, id: usize) -> &mut Self {
@@ -514,17 +520,17 @@ impl Runner {
             self.process(id).env = BTreeMap::new();
         }
 
-        return self;
+        self
     }
 
     pub fn set_children(&mut self, id: usize, children: Vec<i64>) -> &mut Self {
         self.process(id).children = children;
-        return self;
+        self
     }
 
     pub fn new_crash(&mut self, id: usize) -> &mut Self {
         self.process(id).crash.value += 1;
-        return self;
+        self
     }
 
     pub fn stop(&mut self, id: usize) -> &mut Self {
@@ -558,7 +564,7 @@ impl Runner {
             process.children = vec![];
         }
 
-        return self;
+        self
     }
 
     pub fn flush(&mut self, id: usize) -> &mut Self {
@@ -574,7 +580,7 @@ impl Runner {
             self.process(id).logs().flush();
         }
 
-        return self;
+        self
     }
 
     pub fn rename(&mut self, id: usize, name: String) -> &mut Self {
@@ -590,7 +596,7 @@ impl Runner {
             self.process(id).name = name;
         }
 
-        return self;
+        self
     }
 
     pub fn watch(&mut self, id: usize, path: &str, enabled: bool) -> &mut Self {
@@ -601,7 +607,7 @@ impl Runner {
             hash: ternary!(enabled, hash::create(process.path.join(path)), string!("")),
         };
 
-        return self;
+        self
     }
 
     pub fn find(&self, name: &str, server_name: &String) -> Option<usize> {
@@ -643,7 +649,7 @@ impl Runner {
             if let Ok(process) = unix::NativeProcess::new(item.pid as u32)
                 && let Ok(mem_info_native) = process.memory_info()
             {
-                cpu_percent = Some(get_process_cpu_usage_percentage(item.pid as i64));
+                cpu_percent = Some(get_process_cpu_usage_percentage(item.pid));
                 memory_usage = Some(MemoryInfo::from(mem_info_native));
             }
 
@@ -680,7 +686,7 @@ impl Runner {
             });
         }
 
-        return processes;
+        processes
     }
 }
 
@@ -901,7 +907,7 @@ pub fn process_find_children(parent_pid: i64) -> Vec<i64> {
                     if let Ok(Some(ppid)) = process.ppid() {
                         parent_map
                             .entry(ppid as i64)
-                            .or_insert_with(Vec::new)
+                            .or_default()
                             .push(process.pid() as i64);
                     }
                 });

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -161,6 +161,11 @@ pub struct Remote {
     pub config: RemoteConfig,
 }
 
+impl Remote {
+    pub fn address(&self) -> &str { &self.address }
+    pub fn token(&self) -> &Option<String> { &self.token }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct RemoteConfig {
     pub shell: String,

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -7,7 +7,7 @@ pub mod unix;
 use crate::{config, config::structs::Server, file, helpers};
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     env,
     fs::File,
     path::PathBuf,

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -4,18 +4,20 @@ pub mod http;
 pub mod id;
 pub mod unix;
 
-use crate::{
-    config,
-    config::structs::Server,
-    file, helpers,
-};
+use crate::{config, config::structs::Server, file, helpers};
 
 use std::{
-    collections::{HashSet, HashMap}, env, fs::File, path::PathBuf, sync::{Arc, Mutex}, thread, time::Duration,
+    collections::{HashMap, HashSet},
+    env,
+    fs::File,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    thread,
+    time::Duration,
 };
 
 use nix::{
-    sys::signal::{kill, Signal},
+    sys::signal::{Signal, kill},
     unistd::Pid,
 };
 
@@ -162,8 +164,12 @@ pub struct Remote {
 }
 
 impl Remote {
-    pub fn address(&self) -> &str { &self.address }
-    pub fn token(&self) -> &Option<String> { &self.token }
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+    pub fn token(&self) -> &Option<String> {
+        &self.token
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -215,10 +221,10 @@ macro_rules! lock {
 fn kill_children(children: Vec<i64>) {
     for pid in children {
         match kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
-            Ok(_) => {},
+            Ok(_) => {}
             Err(nix::errno::Errno::ESRCH) => {
                 // Process already terminated
-            },
+            }
             Err(err) => {
                 log::error!("Failed to stop pid {}: {err:?}", pid);
             }
@@ -227,9 +233,13 @@ fn kill_children(children: Vec<i64>) {
 }
 
 impl Runner {
-    pub fn new() -> Self { dump::read() }
+    pub fn new() -> Self {
+        dump::read()
+    }
 
-    pub fn refresh(&self) -> Self { Runner::new() }
+    pub fn refresh(&self) -> Self {
+        Runner::new()
+    }
 
     pub fn connect(name: String, Server { address, token }: Server, verbose: bool) -> Option<Self> {
         let remote_config = match config::from(&address, token.as_deref()) {
@@ -241,7 +251,13 @@ impl Runner {
         };
 
         if let Ok(dump) = dump::from(&address, token.as_deref()) {
-            then!(verbose, println!("{} Fetched remote (name={name}, address={address})", *helpers::SUCCESS));
+            then!(
+                verbose,
+                println!(
+                    "{} Fetched remote (name={name}, address={address})",
+                    *helpers::SUCCESS
+                )
+            );
             Some(Runner {
                 remote: Some(Remote {
                     token,
@@ -255,15 +271,28 @@ impl Runner {
         }
     }
 
-    pub fn start(&mut self, name: &String, command: &String, path: PathBuf, watch: &Option<String>) -> &mut Self {
+    pub fn start(
+        &mut self,
+        name: &String,
+        command: &String,
+        path: PathBuf,
+        watch: &Option<String>,
+    ) -> &mut Self {
         if let Some(remote) = &self.remote {
             if let Err(err) = http::create(remote, name, command, path, watch) {
-                crashln!("{} Failed to start create {name}\nError: {:#?}", *helpers::FAIL, err);
+                crashln!(
+                    "{} Failed to start create {name}\nError: {:#?}",
+                    *helpers::FAIL,
+                    err
+                );
             };
         } else {
             let id = self.id.next();
             let config = config::read().runner;
-            let crash = Crash { crashed: false, value: 0 };
+            let crash = Crash {
+                crashed: false,
+                value: 0,
+            };
 
             let watch = match watch {
                 Some(watch) => Watch {
@@ -285,7 +314,8 @@ impl Runner {
                 command: command.clone(),
                 log_path: config.log_path,
                 env: unix::env(),
-            }).unwrap_or_else(|err| crashln!("Failed to run process: {err}"));
+            })
+            .unwrap_or_else(|err| crashln!("Failed to run process: {err}"));
 
             self.list.insert(
                 id,
@@ -312,23 +342,39 @@ impl Runner {
     pub fn restart(&mut self, id: usize, dead: bool) -> &mut Self {
         if let Some(remote) = &self.remote {
             if let Err(err) = http::restart(remote, id) {
-                crashln!("{} Failed to start process {id}\nError: {:#?}", *helpers::FAIL, err);
+                crashln!(
+                    "{} Failed to start process {id}\nError: {:#?}",
+                    *helpers::FAIL,
+                    err
+                );
             };
         } else {
             let process = self.process(id);
             let config = config::read().runner;
-            let Process { path, script, name, .. } = process.clone();
+            let Process {
+                path, script, name, ..
+            } = process.clone();
 
             kill_children(process.children.clone());
-            process_stop(process.pid).unwrap_or_else(|err| crashln!("Failed to stop process: {err}"));
+            process_stop(process.pid)
+                .unwrap_or_else(|err| crashln!("Failed to stop process: {err}"));
 
             if let Err(err) = std::env::set_current_dir(&path) {
                 process.running = false;
                 process.children = vec![];
                 process.crash.crashed = true;
-                println!("{} Failed to set working directory {:?}\nError: {:#?}", *helpers::FAIL, path, err);
+                println!(
+                    "{} Failed to set working directory {:?}\nError: {:#?}",
+                    *helpers::FAIL,
+                    path,
+                    err
+                );
             } else {
-                let mut temp_env = process.env.iter().map(|(key, value)| format!("{}={}", key, value)).collect::<Vec<String>>();
+                let mut temp_env = process
+                    .env
+                    .iter()
+                    .map(|(key, value)| format!("{}={}", key, value))
+                    .collect::<Vec<String>>();
                 temp_env.extend(unix::env());
 
                 process.pid = process_run(ProcessMetadata {
@@ -338,7 +384,8 @@ impl Runner {
                     log_path: config.log_path,
                     command: script.to_string(),
                     env: temp_env,
-                }).unwrap_or_else(|err| crashln!("Failed to run process: {err}"));
+                })
+                .unwrap_or_else(|err| crashln!("Failed to run process: {err}"));
 
                 process.running = true;
                 process.children = vec![];
@@ -358,7 +405,11 @@ impl Runner {
     pub fn remove(&mut self, id: usize) {
         if let Some(remote) = &self.remote {
             if let Err(err) = http::remove(remote, id) {
-                crashln!("{} Failed to stop remove {id}\nError: {:#?}", *helpers::FAIL, err);
+                crashln!(
+                    "{} Failed to stop remove {id}\nError: {:#?}",
+                    *helpers::FAIL,
+                    err
+                );
             };
         } else {
             self.stop(id);
@@ -378,29 +429,60 @@ impl Runner {
         self.save();
     }
 
-    pub fn items(&self) -> BTreeMap<usize, Process> { self.list.clone() }
+    pub fn items(&self) -> BTreeMap<usize, Process> {
+        self.list.clone()
+    }
 
-    pub fn items_mut(&mut self) -> &mut BTreeMap<usize, Process> { &mut self.list }
+    pub fn items_mut(&mut self) -> &mut BTreeMap<usize, Process> {
+        &mut self.list
+    }
 
-    pub fn save(&self) { then!(self.remote.is_none(), dump::write(&self)) }
+    pub fn save(&self) {
+        then!(self.remote.is_none(), dump::write(&self))
+    }
 
-    pub fn count(&mut self) -> usize { self.list().count() }
+    pub fn count(&mut self) -> usize {
+        self.list().count()
+    }
 
-    pub fn is_empty(&self) -> bool { self.list.is_empty() }
+    pub fn is_empty(&self) -> bool {
+        self.list.is_empty()
+    }
 
-    pub fn exists(&self, id: usize) -> bool { self.list.contains_key(&id) }
+    pub fn exists(&self, id: usize) -> bool {
+        self.list.contains_key(&id)
+    }
 
-    pub fn info(&self, id: usize) -> Option<&Process> { self.list.get(&id) }
+    pub fn info(&self, id: usize) -> Option<&Process> {
+        self.list.get(&id)
+    }
 
-    pub fn try_info(&self, id: usize) -> &Process { self.list.get(&id).unwrap_or_else(|| crashln!("{} Process ({id}) not found", *helpers::FAIL)) }
+    pub fn try_info(&self, id: usize) -> &Process {
+        self.list
+            .get(&id)
+            .unwrap_or_else(|| crashln!("{} Process ({id}) not found", *helpers::FAIL))
+    }
 
-    pub fn size(&self) -> Option<&usize> { self.list.iter().map(|(k, _)| k).max() }
+    pub fn size(&self) -> Option<&usize> {
+        self.list.iter().map(|(k, _)| k).max()
+    }
 
-    pub fn list<'l>(&'l mut self) -> impl Iterator<Item = (&'l usize, &'l mut Process)> { self.list.iter_mut().map(|(k, v)| (k, v)) }
+    pub fn list<'l>(&'l mut self) -> impl Iterator<Item = (&'l usize, &'l mut Process)> {
+        self.list.iter_mut().map(|(k, v)| (k, v))
+    }
 
-    pub fn process(&mut self, id: usize) -> &mut Process { self.list.get_mut(&id).unwrap_or_else(|| crashln!("{} Process ({id}) not found", *helpers::FAIL)) }
+    pub fn process(&mut self, id: usize) -> &mut Process {
+        self.list
+            .get_mut(&id)
+            .unwrap_or_else(|| crashln!("{} Process ({id}) not found", *helpers::FAIL))
+    }
 
-    pub fn pid(&self, id: usize) -> i64 { self.list.get(&id).unwrap_or_else(|| crashln!("{} Process ({id}) not found", *helpers::FAIL)).pid }
+    pub fn pid(&self, id: usize) -> i64 {
+        self.list
+            .get(&id)
+            .unwrap_or_else(|| crashln!("{} Process ({id}) not found", *helpers::FAIL))
+            .pid
+    }
 
     pub fn get(self, id: usize) -> ProcessWrapper {
         ProcessWrapper {
@@ -422,7 +504,11 @@ impl Runner {
     pub fn clear_env(&mut self, id: usize) -> &mut Self {
         if let Some(remote) = &self.remote {
             if let Err(err) = http::clear_env(remote, id) {
-                crashln!("{} Failed to clear environment on {id}\nError: {:#?}", *helpers::FAIL, err);
+                crashln!(
+                    "{} Failed to clear environment on {id}\nError: {:#?}",
+                    *helpers::FAIL,
+                    err
+                );
             };
         } else {
             self.process(id).env = BTreeMap::new();
@@ -444,7 +530,11 @@ impl Runner {
     pub fn stop(&mut self, id: usize) -> &mut Self {
         if let Some(remote) = &self.remote {
             if let Err(err) = http::stop(remote, id) {
-                crashln!("{} Failed to stop process {id}\nError: {:#?}", *helpers::FAIL, err);
+                crashln!(
+                    "{} Failed to stop process {id}\nError: {:#?}",
+                    *helpers::FAIL,
+                    err
+                );
             };
         } else {
             let process_to_stop = self.process(id);
@@ -474,7 +564,11 @@ impl Runner {
     pub fn flush(&mut self, id: usize) -> &mut Self {
         if let Some(remote) = &self.remote {
             if let Err(err) = http::flush(remote, id) {
-                crashln!("{} Failed to flush process {id}\nError: {:#?}", *helpers::FAIL, err);
+                crashln!(
+                    "{} Failed to flush process {id}\nError: {:#?}",
+                    *helpers::FAIL,
+                    err
+                );
             };
         } else {
             self.process(id).logs().flush();
@@ -486,7 +580,11 @@ impl Runner {
     pub fn rename(&mut self, id: usize, name: String) -> &mut Self {
         if let Some(remote) = &self.remote {
             if let Err(err) = http::rename(remote, id, name) {
-                crashln!("{} Failed to rename process {id}\nError: {:#?}", *helpers::FAIL, err);
+                crashln!(
+                    "{} Failed to rename process {id}\nError: {:#?}",
+                    *helpers::FAIL,
+                    err
+                );
             };
         } else {
             self.process(id).name = name;
@@ -517,14 +615,22 @@ impl Runner {
             if let Some(server) = servers.get(server_name) {
                 runner = match Runner::connect(server_name.clone(), server.get(), false) {
                     Some(remote) => remote,
-                    None => crashln!("{} Failed to connect (name={server_name}, address={})", *helpers::FAIL, server.address),
+                    None => crashln!(
+                        "{} Failed to connect (name={server_name}, address={})",
+                        *helpers::FAIL,
+                        server.address
+                    ),
                 };
             } else {
                 crashln!("{} Server '{server_name}' does not exist", *helpers::FAIL)
             };
         }
 
-        runner.list.iter().find(|(_, p)| p.name == name).map(|(id, _)| *id)
+        runner
+            .list
+            .iter()
+            .find(|(_, p)| p.name == name)
+            .map(|(id, _)| *id)
     }
 
     pub fn fetch(&self) -> Vec<ProcessItem> {
@@ -534,8 +640,9 @@ impl Runner {
             let mut memory_usage: Option<MemoryInfo> = None;
             let mut cpu_percent: Option<f64> = None;
 
-            if let Ok(process) = unix::NativeProcess::new(item.pid as u32) && 
-                let Ok(mem_info_native) = process.memory_info() {
+            if let Ok(process) = unix::NativeProcess::new(item.pid as u32)
+                && let Ok(mem_info_native) = process.memory_info()
+            {
                 cpu_percent = Some(get_process_cpu_usage_percentage(item.pid as i64));
                 memory_usage = Some(MemoryInfo::from(mem_info_native));
             }
@@ -581,12 +688,20 @@ impl LogInfo {
     pub fn flush(&self) {
         if let Err(err) = File::create(&self.out) {
             log::error!("{err}");
-            crashln!("{} Failed to purge logs (path={})", *helpers::FAIL, self.error);
+            crashln!(
+                "{} Failed to purge logs (path={})",
+                *helpers::FAIL,
+                self.error
+            );
         }
 
         if let Err(err) = File::create(&self.error) {
             log::error!("{err}");
-            crashln!("{} Failed to purge logs (path={})", *helpers::FAIL, self.error);
+            crashln!(
+                "{} Failed to purge logs (path={})",
+                *helpers::FAIL,
+                self.error
+            );
         }
     }
 }
@@ -605,31 +720,49 @@ impl Process {
 
 impl ProcessWrapper {
     /// Stop the process item
-    pub fn stop(&mut self) { lock!(self.runner).stop(self.id).save(); }
+    pub fn stop(&mut self) {
+        lock!(self.runner).stop(self.id).save();
+    }
 
     /// Restart the process item
-    pub fn restart(&mut self) { lock!(self.runner).restart(self.id, false).save(); }
+    pub fn restart(&mut self) {
+        lock!(self.runner).restart(self.id, false).save();
+    }
 
     /// Rename the process item
-    pub fn rename(&mut self, name: String) { lock!(self.runner).rename(self.id, name).save(); }
+    pub fn rename(&mut self, name: String) {
+        lock!(self.runner).rename(self.id, name).save();
+    }
 
     /// Enable watching a path on the process item
-    pub fn watch(&mut self, path: &str) { lock!(self.runner).watch(self.id, path, true).save(); }
+    pub fn watch(&mut self, path: &str) {
+        lock!(self.runner).watch(self.id, path, true).save();
+    }
 
     /// Disable watching on the process item
-    pub fn disable_watch(&mut self) { lock!(self.runner).watch(self.id, "", false).save(); }
+    pub fn disable_watch(&mut self) {
+        lock!(self.runner).watch(self.id, "", false).save();
+    }
 
     /// Set the process item as crashed
-    pub fn crashed(&mut self) { lock!(self.runner).restart(self.id, true).save(); }
+    pub fn crashed(&mut self) {
+        lock!(self.runner).restart(self.id, true).save();
+    }
 
     /// Get the borrowed runner reference (lives till program end)
-    pub fn get_runner(&mut self) -> &Runner { Box::leak(Box::new(lock!(self.runner))) }
+    pub fn get_runner(&mut self) -> &Runner {
+        Box::leak(Box::new(lock!(self.runner)))
+    }
 
     /// Append new environment values to the process item
-    pub fn set_env(&mut self, env: Env) { lock!(self.runner).set_env(self.id, env).save(); }
+    pub fn set_env(&mut self, env: Env) {
+        lock!(self.runner).set_env(self.id, env).save();
+    }
 
     /// Clear environment values of the process item
-    pub fn clear_env(&mut self) { lock!(self.runner).clear_env(self.id).save(); }
+    pub fn clear_env(&mut self) {
+        lock!(self.runner).clear_env(self.id).save();
+    }
 
     /// Get a json dump of the process item
     pub fn fetch(&self) -> ItemSingle {
@@ -641,8 +774,9 @@ impl ProcessWrapper {
         let mut memory_usage: Option<MemoryInfo> = None;
         let mut cpu_percent: Option<f64> = None;
 
-        if let Ok(process) = unix::NativeProcess::new(item.pid as u32) &&
-            let Ok(mem_info_native) = process.memory_info() {
+        if let Ok(process) = unix::NativeProcess::new(item.pid as u32)
+            && let Ok(mem_info_native) = process.memory_info()
+        {
             cpu_percent = Some(get_process_cpu_usage_percentage(item.pid as i64));
             memory_usage = Some(MemoryInfo::from(mem_info_native));
         }
@@ -665,7 +799,12 @@ impl ProcessWrapper {
                 path: item.path.clone(),
                 children: item.children.clone(),
                 uptime: helpers::format_duration(item.started),
-                command: format!("{} {} '{}'", config.shell, config.args.join(" "), item.script.clone()),
+                command: format!(
+                    "{} {} '{}'",
+                    config.shell,
+                    config.args.join(" "),
+                    item.script.clone()
+                ),
             },
             stats: Stats {
                 cpu_percent,
@@ -694,11 +833,9 @@ impl ProcessWrapper {
 /// Get the CPU usage percentage of the process
 pub fn get_process_cpu_usage_percentage(pid: i64) -> f64 {
     match unix::NativeProcess::new(pid as u32) {
-        Ok(process) => {
-            match process.cpu_percent() {
-                Ok(cpu_percent) => cpu_percent.min(100.0 * num_cpus::get() as f64),
-                Err(_) => 0.0,
-            }
+        Ok(process) => match process.cpu_percent() {
+            Ok(cpu_percent) => cpu_percent.min(100.0 * num_cpus::get() as f64),
+            Err(_) => 0.0,
         },
         Err(_) => 0.0,
     }
@@ -707,21 +844,21 @@ pub fn get_process_cpu_usage_percentage(pid: i64) -> f64 {
 /// Stop the process
 pub fn process_stop(pid: i64) -> Result<(), String> {
     let children = process_find_children(pid);
-    
+
     // Stop child processes first
     for child_pid in children {
         let _ = kill(Pid::from_raw(child_pid as i32), Signal::SIGTERM);
         // Continue even if stopping child processes fails
     }
-    
+
     // Stop parent process
     match kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
         Ok(_) => Ok(()),
         Err(nix::errno::Errno::ESRCH) => {
             // Process already terminated
             Ok(())
-        },
-        Err(err) => Err(format!("Failed to stop process {}: {:?}", pid, err))
+        }
+        Err(err) => Err(format!("Failed to stop process {}: {:?}", pid, err)),
     }
 }
 
@@ -762,15 +899,16 @@ pub fn process_find_children(parent_pid: i64) -> Vec<i64> {
 
                 processes.iter().for_each(|process| {
                     if let Ok(Some(ppid)) = process.ppid() {
-                        parent_map.entry(ppid as i64)
+                        parent_map
+                            .entry(ppid as i64)
                             .or_insert_with(Vec::new)
                             .push(process.pid() as i64);
                     }
                 });
 
-                while let Some(pid) = to_check.pop() &&
-                    let Some(direct_children) = parent_map.get(&pid) {
-
+                while let Some(pid) = to_check.pop()
+                    && let Some(direct_children) = parent_map.get(&pid)
+                {
                     for &child in direct_children {
                         if !checked.contains(&child) {
                             children.push(child);
@@ -779,7 +917,7 @@ pub fn process_find_children(parent_pid: i64) -> Vec<i64> {
                         }
                     }
                 }
-            },
+            }
             Err(_) => {
                 log::warn!("Native process enumeration failed for PID {}", parent_pid);
             }
@@ -791,8 +929,8 @@ pub fn process_find_children(parent_pid: i64) -> Vec<i64> {
 
 /// Run the process
 pub fn process_run(metadata: ProcessMetadata) -> Result<i64, String> {
-    use std::process::{Command, Stdio};
     use std::fs::OpenOptions;
+    use std::process::{Command, Stdio};
 
     let log_base = format!("{}/{}", metadata.log_path, metadata.name.replace(' ', "_"));
     let stdout_path = format!("{}-out.log", log_base);
@@ -814,20 +952,21 @@ pub fn process_run(metadata: ProcessMetadata) -> Result<i64, String> {
     // Execute process
     let mut cmd = Command::new(&metadata.shell);
     cmd.args(&metadata.args)
-       .arg(&metadata.command)
-       .envs(metadata.env.iter().map(|env_var| {
-           let parts: Vec<&str> = env_var.splitn(2, '=').collect();
-           if parts.len() == 2 {
-               (parts[0], parts[1])
-           } else {
-               (env_var.as_str(), "")
-           }
-       }))
-       .stdout(Stdio::from(stdout_file))
-       .stderr(Stdio::from(stderr_file))
-       .stdin(Stdio::null());
+        .arg(&metadata.command)
+        .envs(metadata.env.iter().map(|env_var| {
+            let parts: Vec<&str> = env_var.splitn(2, '=').collect();
+            if parts.len() == 2 {
+                (parts[0], parts[1])
+            } else {
+                (env_var.as_str(), "")
+            }
+        }))
+        .stdout(Stdio::from(stdout_file))
+        .stderr(Stdio::from(stderr_file))
+        .stdin(Stdio::null());
 
-    let child = cmd.spawn()
+    let child = cmd
+        .spawn()
         .map_err(|err| format!("Failed to spawn process: {:?}", err))?;
 
     let shell_pid = child.id() as i64;
@@ -855,7 +994,7 @@ mod tests {
     fn test_environment_variables() {
         let mut runner = setup_test_runner();
         let id = runner.id.next();
-        
+
         let process = Process {
             id,
             pid: 12345,
@@ -865,7 +1004,10 @@ mod tests {
             script: "echo 'hello world'".to_string(),
             restarts: 0,
             running: true,
-            crash: Crash { crashed: false, value: 0 },
+            crash: Crash {
+                crashed: false,
+                value: 0,
+            },
             watch: Watch {
                 enabled: false,
                 path: String::new(),
@@ -876,18 +1018,21 @@ mod tests {
         };
 
         runner.list.insert(id, process);
-        
+
         // Test setting environment variables
         let mut env = BTreeMap::new();
         env.insert("TEST_VAR".to_string(), "test_value".to_string());
         env.insert("ANOTHER_VAR".to_string(), "another_value".to_string());
-        
+
         runner.set_env(id, env);
-        
+
         let process_env = &runner.info(id).unwrap().env;
         assert_eq!(process_env.get("TEST_VAR"), Some(&"test_value".to_string()));
-        assert_eq!(process_env.get("ANOTHER_VAR"), Some(&"another_value".to_string()));
-        
+        assert_eq!(
+            process_env.get("ANOTHER_VAR"),
+            Some(&"another_value".to_string())
+        );
+
         // Test clearing environment variables
         runner.clear_env(id);
         assert!(runner.info(id).unwrap().env.is_empty());
@@ -897,7 +1042,7 @@ mod tests {
     fn test_children_processes() {
         let mut runner = setup_test_runner();
         let id = runner.id.next();
-        
+
         let process = Process {
             id,
             pid: 12345,
@@ -907,7 +1052,10 @@ mod tests {
             script: "echo 'hello world'".to_string(),
             restarts: 0,
             running: true,
-            crash: Crash { crashed: false, value: 0 },
+            crash: Crash {
+                crashed: false,
+                value: 0,
+            },
             watch: Watch {
                 enabled: false,
                 path: String::new(),
@@ -918,11 +1066,11 @@ mod tests {
         };
 
         runner.list.insert(id, process);
-        
+
         // Test setting children
         let children = vec![12346, 12347, 12348];
         runner.set_children(id, children.clone());
-        
+
         assert_eq!(runner.info(id).unwrap().children, children);
     }
 
@@ -931,13 +1079,13 @@ mod tests {
         // Test with current process (should return valid percentage)
         let current_pid = std::process::id() as i64;
         let cpu_usage = get_process_cpu_usage_percentage(current_pid);
-        
+
         // CPU usage should be between 0 and 100 * number of cores
         assert!(cpu_usage >= 0.0);
         assert!(cpu_usage <= 100.0 * num_cpus::get() as f64);
 
         println!("CPU usage: {}", cpu_usage);
-        
+
         // Test with invalid PID (should return 0.0)
         let invalid_pid = 999999;
         let cpu_usage = get_process_cpu_usage_percentage(invalid_pid);
@@ -960,10 +1108,10 @@ mod tests {
         match process_run(metadata) {
             Ok(pid) => {
                 assert!(pid > 0);
-                
+
                 // Wait a bit for process to complete
                 thread::sleep(Duration::from_millis(100));
-                
+
                 // Try to stop it (might already be finished)
                 let _ = process_stop(pid);
             }

--- a/src/process/unix/cpu.rs
+++ b/src/process/unix/cpu.rs
@@ -177,7 +177,7 @@ fn get_cpu_percent_mach(pid: u32) -> Option<f64> {
 #[cfg(target_os = "macos")]
 fn get_cpu_percent_ps(pid: u32) -> Option<f64> {
     let output = std::process::Command::new("ps")
-        .args(&["-p", &pid.to_string(), "-o", "pcpu="])
+        .args(["-p", &pid.to_string(), "-o", "pcpu="])
         .output()
         .ok()?;
 

--- a/src/process/unix/cpu.rs
+++ b/src/process/unix/cpu.rs
@@ -27,7 +27,9 @@ pub fn get_cpu_percent(pid: u32) -> f64 {
                             let irq: u64 = cpu_parts[6].parse().ok()?;
                             let softirq: u64 = cpu_parts[7].parse().ok()?;
 
-                            let total_system_time = (user + nice + system + idle + iowait + irq + softirq) as f64 / 100.0;
+                            let total_system_time =
+                                (user + nice + system + idle + iowait + irq + softirq) as f64
+                                    / 100.0;
                             return Some((total_process_time, total_system_time));
                         }
                     }
@@ -102,14 +104,18 @@ fn get_cpu_percent_mach(pid: u32) -> Option<f64> {
 
     unsafe extern "C" {
         fn task_for_pid(target_tport: u32, pid: i32, task: *mut u32) -> i32;
-        fn task_info(target_task: u32, flavor: u32, task_info_out: *mut libc::c_void, task_info_outCnt: *mut u32) -> i32;
+        fn task_info(
+            target_task: u32,
+            flavor: u32,
+            task_info_out: *mut libc::c_void,
+            task_info_outCnt: *mut u32,
+        ) -> i32;
         fn mach_task_self() -> u32;
     }
 
     // Helper to convert TimeValue to seconds
-    let time_to_seconds = |tv: &TimeValue| -> f64 {
-        tv.seconds as f64 + tv.microseconds as f64 / 1_000_000.0
-    };
+    let time_to_seconds =
+        |tv: &TimeValue| -> f64 { tv.seconds as f64 + tv.microseconds as f64 / 1_000_000.0 };
 
     // Get task port for the process
     let mut task: u32 = 0;
@@ -120,7 +126,15 @@ fn get_cpu_percent_mach(pid: u32) -> Option<f64> {
     // Get first measurement
     let mut info: TaskBasicInfo = unsafe { mem::zeroed() };
     let mut count = TASK_BASIC_INFO_COUNT;
-    if unsafe { task_info(task, TASK_BASIC_INFO, &mut info as *mut _ as *mut libc::c_void, &mut count) } != 0 {
+    if unsafe {
+        task_info(
+            task,
+            TASK_BASIC_INFO,
+            &mut info as *mut _ as *mut libc::c_void,
+            &mut count,
+        )
+    } != 0
+    {
         return None;
     }
 
@@ -133,7 +147,15 @@ fn get_cpu_percent_mach(pid: u32) -> Option<f64> {
     // Get second measurement
     let mut info2: TaskBasicInfo = unsafe { mem::zeroed() };
     let mut count2 = TASK_BASIC_INFO_COUNT;
-    if unsafe { task_info(task, TASK_BASIC_INFO, &mut info2 as *mut _ as *mut libc::c_void, &mut count2) } != 0 {
+    if unsafe {
+        task_info(
+            task,
+            TASK_BASIC_INFO,
+            &mut info2 as *mut _ as *mut libc::c_void,
+            &mut count2,
+        )
+    } != 0
+    {
         return None;
     }
 
@@ -161,4 +183,4 @@ fn get_cpu_percent_ps(pid: u32) -> Option<f64> {
 
     let cpu_str = String::from_utf8(output.stdout).ok()?;
     cpu_str.trim().parse::<f64>().ok()
-} 
+}

--- a/src/process/unix/cpu.rs
+++ b/src/process/unix/cpu.rs
@@ -15,23 +15,22 @@ pub fn get_cpu_percent(pid: u32) -> f64 {
                 let total_process_time = (utime + stime) / 100.0; // Convert clock ticks to seconds
 
                 // Get system CPU time
-                if let Ok(stat_content) = fs::read_to_string("/proc/stat") {
-                    if let Some(cpu_line) = stat_content.lines().next() {
-                        let cpu_parts: Vec<&str> = cpu_line.split_whitespace().collect();
-                        if cpu_parts.len() > 7 {
-                            let user: u64 = cpu_parts[1].parse().ok()?;
-                            let nice: u64 = cpu_parts[2].parse().ok()?;
-                            let system: u64 = cpu_parts[3].parse().ok()?;
-                            let idle: u64 = cpu_parts[4].parse().ok()?;
-                            let iowait: u64 = cpu_parts[5].parse().ok()?;
-                            let irq: u64 = cpu_parts[6].parse().ok()?;
-                            let softirq: u64 = cpu_parts[7].parse().ok()?;
+                if let Ok(stat_content) = fs::read_to_string("/proc/stat")
+                    && let Some(cpu_line) = stat_content.lines().next()
+                {
+                    let cpu_parts: Vec<&str> = cpu_line.split_whitespace().collect();
+                    if cpu_parts.len() > 7 {
+                        let user: u64 = cpu_parts[1].parse().ok()?;
+                        let nice: u64 = cpu_parts[2].parse().ok()?;
+                        let system: u64 = cpu_parts[3].parse().ok()?;
+                        let idle: u64 = cpu_parts[4].parse().ok()?;
+                        let iowait: u64 = cpu_parts[5].parse().ok()?;
+                        let irq: u64 = cpu_parts[6].parse().ok()?;
+                        let softirq: u64 = cpu_parts[7].parse().ok()?;
 
-                            let total_system_time =
-                                (user + nice + system + idle + iowait + irq + softirq) as f64
-                                    / 100.0;
-                            return Some((total_process_time, total_system_time));
-                        }
+                        let total_system_time =
+                            (user + nice + system + idle + iowait + irq + softirq) as f64 / 100.0;
+                        return Some((total_process_time, total_system_time));
                     }
                 }
             }

--- a/src/process/unix/env.rs
+++ b/src/process/unix/env.rs
@@ -7,8 +7,12 @@ pub struct Vars {
 
 impl Iterator for Vars {
     type Item = String;
-    fn next(&mut self) -> Option<String> { self.inner.next().map(|var| var.into_string().unwrap()) }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+    fn next(&mut self) -> Option<String> {
+        self.inner.next().map(|var| var.into_string().unwrap())
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -39,7 +43,10 @@ pub fn env() -> Vec<String> {
             }
         }
 
-        return Vars { inner: result.into_iter() }.collect();
+        return Vars {
+            inner: result.into_iter(),
+        }
+        .collect();
     }
 
     fn parse(input: &[u8]) -> Option<OsString> {
@@ -61,4 +68,4 @@ mod tests {
         // Most systems should have PATH environment variable
         assert!(env_vars.iter().any(|var| var.starts_with("PATH=")));
     }
-} 
+}

--- a/src/process/unix/memory.rs
+++ b/src/process/unix/memory.rs
@@ -77,10 +77,10 @@ pub fn get_memory_info(pid: u32) -> Result<NativeMemoryInfo, String> {
                 if let Some(value) = line.split_whitespace().nth(1) {
                     rss = value.parse::<u64>().unwrap_or(0) * 1024; // Convert KB to bytes
                 }
-            } else if line.starts_with("VmSize:") {
-                if let Some(value) = line.split_whitespace().nth(1) {
-                    vms = value.parse::<u64>().unwrap_or(0) * 1024; // Convert KB to bytes
-                }
+            } else if line.starts_with("VmSize:")
+                && let Some(value) = line.split_whitespace().nth(1)
+            {
+                vms = value.parse::<u64>().unwrap_or(0) * 1024; // Convert KB to bytes
             }
         }
 

--- a/src/process/unix/mod.rs
+++ b/src/process/unix/mod.rs
@@ -74,7 +74,7 @@ pub fn get_actual_child_pid(shell_pid: i64) -> i64 {
         return child_pid;
     }
 
-    let pid = if let Ok(processes) = native_processes() {
+    if let Ok(processes) = native_processes() {
         processes
             .iter()
             .find(|process| {
@@ -87,9 +87,7 @@ pub fn get_actual_child_pid(shell_pid: i64) -> i64 {
             .map_or(shell_pid, |p| p.pid() as i64)
     } else {
         shell_pid
-    };
-
-    pid
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -114,9 +112,10 @@ pub fn get_actual_child_pid(shell_pid: i64) -> i64 {
     // Fallback: try using sysctl or other macOS specific methods
     for test_pid in 1..32768 {
         if let Ok(Some(ppid)) = get_parent_pid(test_pid)
-            && ppid as i64 == shell_pid {
-                return test_pid as i64;
-            }
+            && ppid as i64 == shell_pid
+        {
+            return test_pid as i64;
+        }
     }
 
     shell_pid

--- a/src/process/unix/mod.rs
+++ b/src/process/unix/mod.rs
@@ -113,11 +113,10 @@ pub fn get_actual_child_pid(shell_pid: i64) -> i64 {
 
     // Fallback: try using sysctl or other macOS specific methods
     for test_pid in 1..32768 {
-        if let Ok(Some(ppid)) = get_parent_pid(test_pid) {
-            if ppid as i64 == shell_pid {
+        if let Ok(Some(ppid)) = get_parent_pid(test_pid)
+            && ppid as i64 == shell_pid {
                 return test_pid as i64;
             }
-        }
     }
 
     shell_pid

--- a/src/process/unix/process_info.rs
+++ b/src/process/unix/process_info.rs
@@ -84,12 +84,12 @@ pub fn get_process_start_time(_pid: u32) -> Result<SystemTime, String> {
             .map_err(|e| format!("Failed to read process stat: {}", e))?;
 
         let parts: Vec<&str> = stat_content.split_whitespace().collect();
-        if parts.len() > 21 {
-            if let Ok(start_time) = parts[21].parse::<u64>() {
-                // Convert from clock ticks to seconds (simplified)
-                let uptime_secs = start_time / 100;
-                return Ok(UNIX_EPOCH + Duration::from_secs(uptime_secs));
-            }
+        if parts.len() > 21
+            && let Ok(start_time) = parts[21].parse::<u64>()
+        {
+            // Convert from clock ticks to seconds (simplified)
+            let uptime_secs = start_time / 100;
+            return Ok(UNIX_EPOCH + Duration::from_secs(uptime_secs));
         }
     }
 

--- a/src/process/unix/process_list.rs
+++ b/src/process/unix/process_list.rs
@@ -5,17 +5,17 @@ pub fn native_processes() -> Result<Vec<NativeProcess>, String> {
     #[cfg(target_os = "macos")]
     {
         use std::mem;
-        
+
         // Define macOS kinfo_proc structure (simplified)
         #[repr(C)]
         struct KinfoProc {
             kp_proc: ExternProc,
             // We only need the process part for our purposes
         }
-        
+
         #[repr(C)]
         struct ExternProc {
-            p_un: [u8; 16],           // Union, simplified as byte array
+            p_un: [u8; 16], // Union, simplified as byte array
             p_vmspace: u64,
             p_sigacts: u64,
             p_flag: libc::c_int,
@@ -24,12 +24,12 @@ pub fn native_processes() -> Result<Vec<NativeProcess>, String> {
             p_oppid: libc::pid_t,
             p_dupfd: libc::c_int,
             // ... other fields we don't need, represented as padding
-            _padding: [u8; 400],      // Simplified padding to match struct size
+            _padding: [u8; 400], // Simplified padding to match struct size
         }
-        
+
         let mut name: [i32; 3] = [libc::CTL_KERN, libc::KERN_PROC, libc::KERN_PROC_ALL];
         let mut size: libc::size_t = 0;
-        
+
         // Get required buffer size
         let result = unsafe {
             libc::sysctl(
@@ -41,15 +41,15 @@ pub fn native_processes() -> Result<Vec<NativeProcess>, String> {
                 0,
             )
         };
-        
+
         if result < 0 {
             return Err("Failed to get process list size".to_string());
         }
-        
+
         // Allocate buffer
         let num_processes = size / mem::size_of::<KinfoProc>();
         let mut processes_buf: Vec<KinfoProc> = Vec::with_capacity(num_processes);
-        
+
         let result = unsafe {
             libc::sysctl(
                 name.as_mut_ptr(),
@@ -60,52 +60,51 @@ pub fn native_processes() -> Result<Vec<NativeProcess>, String> {
                 0,
             )
         };
-        
+
         if result < 0 {
             return Err("Failed to get process list".to_string());
         }
-        
+
         unsafe {
             processes_buf.set_len(size / mem::size_of::<KinfoProc>());
         }
-        
+
         let mut result_processes = Vec::new();
-        
+
         for kinfo in processes_buf {
             let pid = kinfo.kp_proc.p_pid as u32;
             if let Ok(process) = NativeProcess::new(pid) {
                 result_processes.push(process);
             }
         }
-        
+
         Ok(result_processes)
     }
-    
+
     #[cfg(target_os = "linux")]
     {
         use std::fs;
-        
-        let mut processes = Vec::new();
-        
-        // Read /proc directory
-        let proc_dir = fs::read_dir("/proc")
-            .map_err(|e| format!("Failed to read /proc: {}", e))?;
-        
-        for entry in proc_dir {
-            if let Ok(entry) = entry &&
-                let Ok(file_name) = entry.file_name().into_string() &&
-                let Ok(pid) = file_name.parse::<u32>() &&
-                let Ok(process) = NativeProcess::new(pid) {
 
+        let mut processes = Vec::new();
+
+        // Read /proc directory
+        let proc_dir = fs::read_dir("/proc").map_err(|e| format!("Failed to read /proc: {}", e))?;
+
+        for entry in proc_dir {
+            if let Ok(entry) = entry
+                && let Ok(file_name) = entry.file_name().into_string()
+                && let Ok(pid) = file_name.parse::<u32>()
+                && let Ok(process) = NativeProcess::new(pid)
+            {
                 processes.push(process);
             }
         }
-        
+
         Ok(processes)
     }
-    
+
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
         Err("Unsupported platform".to_string())
     }
-} 
+}

--- a/src/webui/assets.rs
+++ b/src/webui/assets.rs
@@ -10,7 +10,12 @@ use std::{io, path::PathBuf};
 pub struct NamedFile(PathBuf, String);
 
 impl NamedFile {
-    pub async fn send(name: String, contents: Option<&str>) -> io::Result<NamedFile> { Ok(NamedFile(PathBuf::from(name), contents.unwrap().to_string())) }
+    pub async fn send(name: String, contents: Option<&str>) -> io::Result<NamedFile> {
+        Ok(NamedFile(
+            PathBuf::from(name),
+            contents.unwrap().to_string(),
+        ))
+    }
 }
 
 impl<'r> Responder<'r, 'static> for NamedFile {

--- a/src/webui/assets.rs
+++ b/src/webui/assets.rs
@@ -21,11 +21,10 @@ impl NamedFile {
 impl<'r> Responder<'r, 'static> for NamedFile {
     fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
         let mut response = self.1.respond_to(req)?;
-        if let Some(ext) = self.0.extension() {
-            if let Some(ct) = ContentType::from_extension(&ext.to_string_lossy()) {
+        if let Some(ext) = self.0.extension()
+            && let Some(ct) = ContentType::from_extension(&ext.to_string_lossy()) {
                 response.set_header(ct);
             }
-        }
 
         Ok(response)
     }

--- a/src/webui/assets.rs
+++ b/src/webui/assets.rs
@@ -22,9 +22,10 @@ impl<'r> Responder<'r, 'static> for NamedFile {
     fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
         let mut response = self.1.respond_to(req)?;
         if let Some(ext) = self.0.extension()
-            && let Some(ct) = ContentType::from_extension(&ext.to_string_lossy()) {
-                response.set_header(ct);
-            }
+            && let Some(ct) = ContentType::from_extension(&ext.to_string_lossy())
+        {
+            response.set_header(ct);
+        }
 
         Ok(response)
     }

--- a/src/webui/mod.rs
+++ b/src/webui/mod.rs
@@ -15,7 +15,7 @@ pub fn create_templates() -> (Tera, String) {
     ])
     .unwrap();
 
-    return (tera, path.trim_end_matches('/').to_string());
+    (tera, path.trim_end_matches('/').to_string())
 }
 
 pub mod assets;


### PR DESCRIPTION
## Summary

  - add authenticated websocket log streaming endpoints (local + remote proxy) alongside deprecated HTTP log routes
  - switch CLI pmc logs to stream stdout/stderr over WS with automatic fallback and better error surfacing
  - move web UI log viewer to WS (token via query), using snapshot + incremental line frames with reconnect/backoff

## Testing
  - cargo clippy (warnings only from existing code)
  
  ## Additional
  - Applied cargo fmt
  - Applied cargo clippy
  - Bump dependency versions

if you don't want to get `fmt`, `clippy`, bumping versions, you can just cherry pick first commit!